### PR TITLE
Refine error message for send:api_response

### DIFF
--- a/custom_components/dreame_mower/camera.py
+++ b/custom_components/dreame_mower/camera.py
@@ -449,6 +449,10 @@ class DreameMowerCameraEntity(DreameMowerEntity, Camera):
         self.access_tokens = collections.deque([], 2)
         self.async_update_token()
         self._rtsp_to_webrtc = False
+        self._webrtc_provider = None
+        self._legacy_webrtc_provider = None
+        self._supports_native_sync_webrtc = False
+        self._supports_native_async_webrtc = False
         self._should_poll = True
         self._last_updated = -1
         self._frame_id = -1

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -4829,7 +4829,7 @@ class DreameMowerDeviceStatus:
         response = self._get_property(DreameMowerProperty.LENSBRUSH_LEFT)
         if response and "CMS" not in response:
             _LOGGER.warning("DreameMowerDeviceStatus.lensbrush_life CMS missing in response: %s", response)
-            return 100  # return some fake lensbursh life
+            return 100  # return some fake lensbrush life in percent
         return 30000 - self._get_property(DreameMowerProperty.LENSBRUSH_LEFT)['CMS'][0]
 
     @property

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -4826,6 +4826,10 @@ class DreameMowerDeviceStatus:
     @property
     def lensbrush_life(self) -> int:
         """Returns lensbrush life in percent."""
+        response = self._get_property(DreameMowerProperty.LENSBRUSH_LEFT)
+        if response and "CMS" not in response:
+            _LOGGER.warning("DreameMowerDeviceStatus.lensbrush_life CMS missing in response: %s", response)
+            return 100  # return some fake lensbursh life
         return 30000 - self._get_property(DreameMowerProperty.LENSBRUSH_LEFT)['CMS'][0]
 
     @property

--- a/custom_components/dreame_mower/dreame/protocol.py
+++ b/custom_components/dreame_mower/dreame/protocol.py
@@ -466,9 +466,15 @@ class DreameMowerDreameHomeCloudProtocol:
             return None
 
         if api_response is None or "data" not in api_response or "result" not in api_response["data"]:
-            _LOGGER.warning(
-                "DreameMowerDreameHomeCloudProtocol.send failed: %s", api_response)
+            if api_response["code"] != 0:
+                # Print a warning only in case response reports an error.
+                _LOGGER.warning(
+                    "DreameMowerDreameHomeCloudProtocol.send failed: %s", api_response)
+
+            # Seems like sometimes the response can be successful (code == 0), but data
+            # still empty. In this case don't print any errors, but return None.
             return None
+        
         return api_response["data"]["result"]
 
     def get_file(self, url: str, retry_count: int = 4) -> Any:


### PR DESCRIPTION
It seems like that in some scenarios the response is successful, but the 'data' still empty. Print a warning only if response.code != 0