### PR TITLE
Implement zone map

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Build release zip
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build-zip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build dreame_mower.zip
+        run: cd custom_components/dreame_mower && zip -r ../../dreame_mower.zip . -x '__pycache__/*' '*.pyc'
+
+      - name: Upload zip to release
+        run: gh release upload "${{ github.event.release.tag_name }}" dreame_mower.zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/custom_components/dreame_mower/camera.py
+++ b/custom_components/dreame_mower/camera.py
@@ -58,6 +58,7 @@ from .dreame.map import (
     DreameMowerMapRenderer,
     DreameMowerMapDataJsonRenderer,
 )
+from .dreame.map_renderer import MowerVectorMapRenderer
 
 DREAME_TOKEN_CHANGE_INTERVAL: Final = timedelta(minutes=60)
 
@@ -481,6 +482,8 @@ class DreameMowerCameraEntity(DreameMowerEntity, Camera):
                     square,
                     False,
                 )
+        # Vector map renderer for polygon-based mower maps
+        self._vector_renderer = MowerVectorMapRenderer()
         self._image = None
         self._default_map = True
         self._proxy_images = {}
@@ -775,6 +778,20 @@ class DreameMowerCameraEntity(DreameMowerEntity, Camera):
 
     async def _update_image(self, map_data, robot_status, station_status) -> None:
         try:
+            # Prefer vector map rendering for mower polygon data
+            vector_map = self.device.vector_map if self.device else None
+            if vector_map and vector_map.boundary:
+                rendered = await self.coordinator.hass.async_add_executor_job(
+                    self._vector_renderer.render, vector_map
+                )
+                if rendered:
+                    self._image = rendered
+                    if not self.map_data_json and self._calibration_points != self._renderer.calibration_points:
+                        self._calibration_points = self._renderer.calibration_points
+                        self.coordinator.set_updated_data()
+                    return
+
+            # Fall back to existing pixel-based renderer
             self._image = self._renderer.render_map(map_data, robot_status, station_status)
             if not self.map_data_json and self._calibration_points != self._renderer.calibration_points:
                 self._calibration_points = self._renderer.calibration_points

--- a/custom_components/dreame_mower/camera.py
+++ b/custom_components/dreame_mower/camera.py
@@ -443,6 +443,10 @@ class DreameMowerCameraEntity(DreameMowerEntity, Camera):
     ) -> None:
         """Initialize a Dreame Mower Camera entity."""
         super().__init__(coordinator, description)
+        # Set attributes needed by async_update_token() before Camera.__init__
+        # calls it during setup
+        self._access_token_update_counter = 0
+        self.access_tokens = collections.deque([], 2)
         Camera.__init__(self)
         self._generate_entity_id(ENTITY_ID_FORMAT)
         self.content_type = PNG_CONTENT_TYPE
@@ -632,6 +636,26 @@ class DreameMowerCameraEntity(DreameMowerEntity, Camera):
 
     def update(self) -> None:
         map_data = self._map_data
+
+        # Try vector map rendering even without pixel map data
+        vector_map = self.device.vector_map if self.device else None
+        if vector_map and vector_map.boundary and self.map_index == 0 and not self.map_data_json:
+            vmap_updated = vector_map.last_updated
+            if vmap_updated and vmap_updated != self._last_updated and self._vector_renderer.render_complete:
+                self._last_updated = vmap_updated
+                self._default_map = False
+                self._state = datetime.fromtimestamp(int(vmap_updated))
+                self.coordinator.hass.async_create_task(
+                    self._update_image(
+                        self.device.get_map_for_render(self._map_data) if map_data else None,
+                        self.device.status.robot_status,
+                        0,  # station_status not applicable for mowers
+                    )
+                )
+            # Always return when vector map exists — don't fall through to
+            # pixel map path which would reset state to unavailable
+            return
+
         if map_data and self.device.cloud_connected and (self.map_index > 0 or self.device.status.located):
             self._device_active = self.device.status.active
             if map_data.last_updated:

--- a/custom_components/dreame_mower/camera.py
+++ b/custom_components/dreame_mower/camera.py
@@ -443,12 +443,10 @@ class DreameMowerCameraEntity(DreameMowerEntity, Camera):
     ) -> None:
         """Initialize a Dreame Mower Camera entity."""
         super().__init__(coordinator, description)
+        Camera.__init__(self)
         self._generate_entity_id(ENTITY_ID_FORMAT)
         self.content_type = PNG_CONTENT_TYPE
         self.stream = None
-        self._access_token_update_counter = 0
-        self.access_tokens = collections.deque([], 2)
-        self.async_update_token()
         self._rtsp_to_webrtc = False
         self._should_poll = True
         self._last_updated = -1

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -1826,6 +1826,13 @@ class DreameMowerDevice:
             return render_map_data
         return map_data
 
+    @property
+    def vector_map(self):
+        """Get the current vector map data from the map manager."""
+        if self._map_manager:
+            return self._map_manager.vector_map
+        return None
+
     def get_map(self, map_index: int) -> MapData | None:
         """Get stored map data by index from map manager."""
         if self._map_manager:

--- a/custom_components/dreame_mower/dreame/map.py
+++ b/custom_components/dreame_mower/dreame/map.py
@@ -36,9 +36,11 @@ from threading import Timer
 from .resources import *
 from .protocol import DreameMowerProtocol
 from .exceptions import DeviceUpdateFailedException
+from .map_data_parser import parse_batch_map_data
 from .types import (
     PIID,
     DIID,
+    MowerVectorMap,
     DreameMowerProperty,
     DreameMowerAction,
     DreameMowerActionMapping,
@@ -195,6 +197,63 @@ class DreameMapMowerMapManager:
         self._new_map_request_time: int = None
         self._aes_iv: str = None
         self._capability: DreameMowerDeviceCapability = None
+        self._vector_map: MowerVectorMap | None = None
+
+    @property
+    def vector_map(self) -> MowerVectorMap | None:
+        """Get the current vector map data (for mower polygon rendering)."""
+        return self._vector_map
+
+    def _fetch_vector_map_from_batch_api(self) -> bool:
+        """Fetch vector map data from the batch device data API.
+
+        Requests MAP.*, M_PATH.*, and SETTINGS.* keys from the cloud
+        batch API and parses them into a MowerVectorMap.
+
+        Returns:
+            True if map data was updated, False otherwise.
+        """
+        if not self._protocol.cloud or not self._protocol.cloud.logged_in:
+            return False
+
+        try:
+            # Build the list of keys to fetch
+            keys = []
+            # MAP chunks — request up to 40 (typical is 0-32)
+            for i in range(40):
+                keys.append(f"MAP.{i}")
+            keys.append("MAP.info")
+            # M_PATH chunks
+            for i in range(10):
+                keys.append(f"M_PATH.{i}")
+            keys.append("M_PATH.info")
+            # Settings
+            for i in range(5):
+                keys.append(f"SETTINGS.{i}")
+            keys.append("SETTINGS.info")
+
+            batch_data = self._protocol.cloud.get_batch_device_datas(keys)
+            if not batch_data:
+                _LOGGER.debug("No batch data returned from cloud API")
+                return False
+
+            vector_map = parse_batch_map_data(batch_data)
+            if vector_map is None:
+                _LOGGER.debug("Failed to parse batch map data")
+                return False
+
+            self._vector_map = vector_map
+            _LOGGER.debug(
+                "Vector map updated: %d zones, %d paths, boundary=%s",
+                len(vector_map.zones),
+                len(vector_map.paths),
+                vector_map.boundary,
+            )
+            return True
+
+        except Exception as ex:
+            _LOGGER.warning("Failed to fetch vector map from batch API: %s", ex)
+            return False
 
     def _request_map_from_cloud(self) -> bool:
         if self._protocol.cloud.dreame_cloud:
@@ -1271,6 +1330,14 @@ class DreameMapMowerMapManager:
             if not self._available and self._connected:
                 self._available = True
                 self._map_data_changed()
+
+            # Fetch vector map data from batch API (for mower polygon rendering)
+            if self._protocol.dreame_cloud and self._protocol.cloud.connected:
+                if (self._vector_map is None
+                        or self._device_running
+                        or (self._vector_map.last_updated and time.time() - self._vector_map.last_updated > 300)):
+                    if self._fetch_vector_map_from_batch_api():
+                        self._map_data_changed()
         except Exception as ex:
             if self._available:
                 _LOGGER.warning("Map update Failed: %s", traceback.format_exc())

--- a/custom_components/dreame_mower/dreame/map_data_parser.py
+++ b/custom_components/dreame_mower/dreame/map_data_parser.py
@@ -126,63 +126,64 @@ def parse_mower_map(map_json_str: str) -> MowerVectorMap:
 def parse_mow_paths(batch_data: dict) -> list[MowerMowPath]:
     """Parse M_PATH.* keys from batch data into MowerMowPath objects.
 
-    Each M_PATH.N key contains a coordinate array for zone N.
-    Coordinates are comma-separated pairs: [x1,y1],[x2,y2],...
-    The sentinel [32767,-32768] marks a segment break.
+    M_PATH data is chunked across numbered keys (M_PATH.0, M_PATH.1, ...)
+    just like MAP data. The chunks must be reassembled into a single string.
+    M_PATH.info contains the split position for multi-map data.
+
+    The reassembled string contains [x,y] coordinate pairs with
+    [32767,-32768] sentinels marking segment breaks.
 
     Args:
         batch_data: dict from get_batch_device_datas response
 
     Returns:
-        List of MowerMowPath objects.
+        List of MowerMowPath objects (one per zone, zone_id=0).
     """
-    pattern = re.compile(r"^M_PATH\.(\d+)$")
-    paths = []
+    raw = reassemble_map_chunks(batch_data, "M_PATH")
+    if not raw:
+        return []
 
-    for key, value in batch_data.items():
-        match = pattern.match(key)
-        if not match:
-            continue
+    # M_PATH.info is the split position (like MAP.info)
+    # Skip the first map's data (typically empty "[]")
+    info = batch_data.get("M_PATH.info", "")
+    try:
+        split_pos = int(info) if info.isdigit() else 0
+    except (ValueError, AttributeError):
+        split_pos = 0
 
-        zone_id = int(match.group(1))
-        value = value.strip()
+    if split_pos > 0 and split_pos < len(raw):
+        raw = raw[split_pos:]
 
-        if not value or value == "[]":
-            continue
+    if not raw.strip() or raw.strip() == "[]":
+        return []
 
-        # Parse the coordinate pairs from the string
-        # Format: [x,y],[x,y],... or just x,y,x,y,...
-        # We need to handle: ",[32767,-32768],[10,20],[30,40]"
-        # Strip leading/trailing brackets and commas
-        coords_str = value.strip("[], ")
-        if not coords_str:
-            continue
+    # Extract all [x,y] coordinate pairs using regex.
+    # This is robust against chunk boundary artifacts since it
+    # only matches well-formed [int,int] pairs.
+    pair_pattern = re.compile(r"\[(-?\d+),(-?\d+)\]")
+    pairs = [(int(m.group(1)), int(m.group(2))) for m in pair_pattern.finditer(raw)]
 
-        # Parse all numbers
-        numbers = re.findall(r"-?\d+", coords_str)
-        if len(numbers) % 2 != 0:
-            _LOGGER.warning("Odd number of coordinates in M_PATH.%d, skipping last", zone_id)
-            numbers = numbers[:-1]
+    if not pairs:
+        return []
 
-        # Build coordinate pairs, splitting on sentinel
-        segments = []
-        current_segment = []
-        for i in range(0, len(numbers), 2):
-            x, y = int(numbers[i]), int(numbers[i + 1])
-            if (x, y) == _PATH_SENTINEL:
-                if current_segment:
-                    segments.append(current_segment)
-                    current_segment = []
-            else:
-                current_segment.append((x, y))
+    # Split on sentinel into segments
+    segments = []
+    current_segment = []
+    for p in pairs:
+        if p == _PATH_SENTINEL:
+            if current_segment:
+                segments.append(current_segment)
+                current_segment = []
+        else:
+            current_segment.append(p)
 
-        if current_segment:
-            segments.append(current_segment)
+    if current_segment:
+        segments.append(current_segment)
 
-        if segments:
-            paths.append(MowerMowPath(zone_id=zone_id, segments=segments))
+    if segments:
+        return [MowerMowPath(zone_id=0, segments=segments)]
 
-    return paths
+    return []
 
 
 def parse_batch_map_data(batch_data: dict) -> MowerVectorMap | None:

--- a/custom_components/dreame_mower/dreame/map_data_parser.py
+++ b/custom_components/dreame_mower/dreame/map_data_parser.py
@@ -1,0 +1,246 @@
+"""Parser for mower vector map data from the Dreame batch device data API.
+
+The batch API returns map data split across numbered keys (MAP.0, MAP.1, ...).
+These chunks must be concatenated in numeric order to form a complete JSON string.
+The JSON contains polygon-based zone boundaries, navigation paths, and metadata.
+"""
+import json
+import logging
+import re
+import time
+
+from .types import (
+    MowerMapBoundary,
+    MowerMowPath,
+    MowerPath,
+    MowerVectorMap,
+    MowerZone,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Sentinel value in M_PATH data marking a path segment break
+_PATH_SENTINEL = (32767, -32768)
+
+
+def reassemble_map_chunks(batch_data: dict, prefix: str) -> str | None:
+    """Reassemble chunked data from batch API into a single string.
+
+    Keys like MAP.0, MAP.1, ... MAP.N are concatenated in numeric order.
+    The MAP.info key is skipped (it's metadata, not map content).
+
+    Args:
+        batch_data: dict from get_batch_device_datas response
+        prefix: key prefix to match, e.g. "MAP" or "M_PATH"
+
+    Returns:
+        Concatenated string, or None if no matching keys found.
+    """
+    pattern = re.compile(rf"^{re.escape(prefix)}\.(\d+)$")
+    chunks = []
+    for key, value in batch_data.items():
+        match = pattern.match(key)
+        if match:
+            chunks.append((int(match.group(1)), value))
+
+    if not chunks:
+        return None
+
+    chunks.sort(key=lambda x: x[0])
+    return "".join(value for _, value in chunks)
+
+
+def _parse_polygon_list(data_map: dict) -> list:
+    """Parse a dataType:Map structure containing polygon entries."""
+    if not data_map or data_map.get("dataType") != "Map":
+        return []
+    return data_map.get("value", [])
+
+
+def _extract_path_coords(path_list: list) -> list[tuple[int, int]]:
+    """Convert [{"x": ..., "y": ...}, ...] to [(x, y), ...]."""
+    return [(p["x"], p["y"]) for p in path_list]
+
+
+def parse_mower_map(map_json_str: str) -> MowerVectorMap:
+    """Parse a single map JSON string into a MowerVectorMap.
+
+    Args:
+        map_json_str: JSON string for one map (after unescaping from the chunk array).
+
+    Returns:
+        MowerVectorMap with zones, paths, boundary, etc.
+    """
+    data = json.loads(map_json_str)
+    vmap = MowerVectorMap()
+
+    # Parse mowing area zones
+    for entry in _parse_polygon_list(data.get("mowingAreas", {})):
+        zone_id, zone_data = entry[0], entry[1]
+        vmap.zones.append(MowerZone(
+            zone_id=zone_id,
+            path=_extract_path_coords(zone_data.get("path", [])),
+            name=zone_data.get("name", ""),
+            zone_type=zone_data.get("type", 0),
+            shape_type=zone_data.get("shapeType", 0),
+            area=zone_data.get("area", 0),
+            time=zone_data.get("time", 0),
+            etime=zone_data.get("etime", 0),
+        ))
+
+    # Parse forbidden areas
+    for entry in _parse_polygon_list(data.get("forbiddenAreas", {})):
+        zone_id, zone_data = entry[0], entry[1]
+        vmap.forbidden_areas.append(MowerZone(
+            zone_id=zone_id,
+            path=_extract_path_coords(zone_data.get("path", [])),
+            name=zone_data.get("name", ""),
+            zone_type=zone_data.get("type", 0),
+        ))
+
+    # Parse navigation paths between zones
+    for entry in _parse_polygon_list(data.get("paths", {})):
+        path_id, path_data = entry[0], entry[1]
+        vmap.paths.append(MowerPath(
+            path_id=path_id,
+            path=_extract_path_coords(path_data.get("path", [])),
+            path_type=path_data.get("type", 0),
+        ))
+
+    # Parse boundary
+    boundary = data.get("boundary")
+    if boundary:
+        vmap.boundary = MowerMapBoundary(
+            x1=boundary["x1"], y1=boundary["y1"],
+            x2=boundary["x2"], y2=boundary["y2"],
+        )
+
+    vmap.total_area = data.get("totalArea", 0)
+    vmap.name = data.get("name", "")
+    vmap.map_index = data.get("mapIndex", 0)
+    vmap.last_updated = time.time()
+
+    return vmap
+
+
+def parse_mow_paths(batch_data: dict) -> list[MowerMowPath]:
+    """Parse M_PATH.* keys from batch data into MowerMowPath objects.
+
+    Each M_PATH.N key contains a coordinate array for zone N.
+    Coordinates are comma-separated pairs: [x1,y1],[x2,y2],...
+    The sentinel [32767,-32768] marks a segment break.
+
+    Args:
+        batch_data: dict from get_batch_device_datas response
+
+    Returns:
+        List of MowerMowPath objects.
+    """
+    pattern = re.compile(r"^M_PATH\.(\d+)$")
+    paths = []
+
+    for key, value in batch_data.items():
+        match = pattern.match(key)
+        if not match:
+            continue
+
+        zone_id = int(match.group(1))
+        value = value.strip()
+
+        if not value or value == "[]":
+            continue
+
+        # Parse the coordinate pairs from the string
+        # Format: [x,y],[x,y],... or just x,y,x,y,...
+        # We need to handle: ",[32767,-32768],[10,20],[30,40]"
+        # Strip leading/trailing brackets and commas
+        coords_str = value.strip("[], ")
+        if not coords_str:
+            continue
+
+        # Parse all numbers
+        numbers = re.findall(r"-?\d+", coords_str)
+        if len(numbers) % 2 != 0:
+            _LOGGER.warning("Odd number of coordinates in M_PATH.%d, skipping last", zone_id)
+            numbers = numbers[:-1]
+
+        # Build coordinate pairs, splitting on sentinel
+        segments = []
+        current_segment = []
+        for i in range(0, len(numbers), 2):
+            x, y = int(numbers[i]), int(numbers[i + 1])
+            if (x, y) == _PATH_SENTINEL:
+                if current_segment:
+                    segments.append(current_segment)
+                    current_segment = []
+            else:
+                current_segment.append((x, y))
+
+        if current_segment:
+            segments.append(current_segment)
+
+        if segments:
+            paths.append(MowerMowPath(zone_id=zone_id, segments=segments))
+
+    return paths
+
+
+def parse_batch_map_data(batch_data: dict) -> MowerVectorMap | None:
+    """Parse complete batch device data response into a MowerVectorMap.
+
+    This is the main entry point. It:
+    1. Reassembles MAP.* chunks into a full JSON string
+    2. Parses the JSON array (may contain multiple maps by mapIndex)
+    3. Returns the primary map (mapIndex 0)
+    4. Attaches mowing paths from M_PATH.* keys
+
+    Args:
+        batch_data: Full response dict from get_batch_device_datas
+
+    Returns:
+        MowerVectorMap for the primary map, or None if parsing fails.
+    """
+    if not batch_data:
+        return None
+
+    raw_map = reassemble_map_chunks(batch_data, "MAP")
+    if not raw_map:
+        _LOGGER.debug("No MAP chunks found in batch data")
+        return None
+
+    try:
+        # The reassembled string is a JSON array of JSON strings
+        map_array = json.loads(raw_map)
+    except json.JSONDecodeError:
+        _LOGGER.warning("Failed to parse reassembled MAP data as JSON")
+        return None
+
+    if not map_array:
+        return None
+
+    # Parse each map entry — they're JSON strings within the array
+    primary_map = None
+    for map_json_str in map_array:
+        try:
+            vmap = parse_mower_map(map_json_str)
+            if vmap.map_index == 0:
+                primary_map = vmap
+        except (json.JSONDecodeError, KeyError, TypeError) as ex:
+            _LOGGER.warning("Failed to parse map entry: %s", ex)
+            continue
+
+    if primary_map is None and map_array:
+        # Fall back to first entry if no mapIndex 0 found
+        try:
+            primary_map = parse_mower_map(map_array[0])
+        except (json.JSONDecodeError, KeyError, TypeError) as ex:
+            _LOGGER.warning("Failed to parse fallback map entry: %s", ex)
+            return None
+
+    if primary_map is None:
+        return None
+
+    # Attach mowing paths
+    primary_map.mow_paths = parse_mow_paths(batch_data)
+
+    return primary_map

--- a/custom_components/dreame_mower/dreame/map_data_parser.py
+++ b/custom_components/dreame_mower/dreame/map_data_parser.py
@@ -208,19 +208,40 @@ def parse_batch_map_data(batch_data: dict) -> MowerVectorMap | None:
         _LOGGER.debug("No MAP chunks found in batch data")
         return None
 
+    # MAP.info contains the character length of the primary JSON array.
+    # The full reassembled string may contain multiple JSON arrays
+    # concatenated (one per map), so we use MAP.info to split them.
+    map_info = batch_data.get("MAP.info", "")
+    map_arrays = []
     try:
-        # The reassembled string is a JSON array of JSON strings
-        map_array = json.loads(raw_map)
-    except json.JSONDecodeError:
-        _LOGGER.warning("Failed to parse reassembled MAP data as JSON")
-        return None
+        split_pos = int(map_info) if map_info.isdigit() else 0
+    except (ValueError, AttributeError):
+        split_pos = 0
 
-    if not map_array:
+    if split_pos > 0 and split_pos < len(raw_map):
+        # Split into individual JSON arrays
+        parts = [raw_map[:split_pos], raw_map[split_pos:]]
+    else:
+        parts = [raw_map]
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            arr = json.loads(part)
+            if isinstance(arr, list):
+                map_arrays.extend(arr)
+        except json.JSONDecodeError:
+            _LOGGER.debug("Failed to parse MAP chunk part (len=%d)", len(part))
+
+    if not map_arrays:
+        _LOGGER.warning("No valid MAP arrays found in batch data")
         return None
 
     # Parse each map entry — they're JSON strings within the array
     primary_map = None
-    for map_json_str in map_array:
+    for map_json_str in map_arrays:
         try:
             vmap = parse_mower_map(map_json_str)
             if vmap.map_index == 0:
@@ -229,10 +250,10 @@ def parse_batch_map_data(batch_data: dict) -> MowerVectorMap | None:
             _LOGGER.warning("Failed to parse map entry: %s", ex)
             continue
 
-    if primary_map is None and map_array:
+    if primary_map is None and map_arrays:
         # Fall back to first entry if no mapIndex 0 found
         try:
-            primary_map = parse_mower_map(map_array[0])
+            primary_map = parse_mower_map(map_arrays[0])
         except (json.JSONDecodeError, KeyError, TypeError) as ex:
             _LOGGER.warning("Failed to parse fallback map entry: %s", ex)
             return None

--- a/custom_components/dreame_mower/dreame/map_data_parser.py
+++ b/custom_components/dreame_mower/dreame/map_data_parser.py
@@ -160,22 +160,24 @@ def parse_mow_paths(batch_data: dict) -> list[MowerMowPath]:
     # Extract all [x,y] coordinate pairs using regex.
     # This is robust against chunk boundary artifacts since it
     # only matches well-formed [int,int] pairs.
+    # M_PATH coordinates are at 1/10th scale compared to zone coordinates
+    # (decimeters vs centimeters), so we scale by 10 after sentinel detection.
     pair_pattern = re.compile(r"\[(-?\d+),(-?\d+)\]")
-    pairs = [(int(m.group(1)), int(m.group(2))) for m in pair_pattern.finditer(raw)]
+    raw_pairs = [(int(m.group(1)), int(m.group(2))) for m in pair_pattern.finditer(raw)]
 
-    if not pairs:
+    if not raw_pairs:
         return []
 
-    # Split on sentinel into segments
+    # Split on sentinel into segments, then scale coordinates
     segments = []
     current_segment = []
-    for p in pairs:
+    for p in raw_pairs:
         if p == _PATH_SENTINEL:
             if current_segment:
                 segments.append(current_segment)
                 current_segment = []
         else:
-            current_segment.append(p)
+            current_segment.append((p[0] * 10, p[1] * 10))
 
     if current_segment:
         segments.append(current_segment)

--- a/custom_components/dreame_mower/dreame/map_renderer.py
+++ b/custom_components/dreame_mower/dreame/map_renderer.py
@@ -105,12 +105,10 @@ class MowerVectorMapRenderer:
         def to_pixel(x: int, y: int) -> tuple[int, int]:
             """Convert map coordinates to pixel coordinates.
 
-            Map coordinates: Y increases upward (north).
-            Pixel coordinates: Y increases downward.
-            No flip needed — higher Y values in map coords should appear
-            higher (lower pixel Y) on screen, so we invert.
+            X axis is mirrored to match the Dreame app's orientation.
+            Y axis maps directly (higher Y = lower on screen).
             """
-            px = int((x - boundary.x1) * scale) + _PADDING
+            px = img_w - (int((x - boundary.x1) * scale) + _PADDING)
             py = int((y - boundary.y1) * scale) + _PADDING
             return (px, py)
 

--- a/custom_components/dreame_mower/dreame/map_renderer.py
+++ b/custom_components/dreame_mower/dreame/map_renderer.py
@@ -16,26 +16,25 @@ _LOGGER = logging.getLogger(__name__)
 _MAX_IMAGE_SIZE = 2048  # Max pixels on longest side
 _MIN_IMAGE_SIZE = 400   # Min pixels on longest side
 _PADDING = 40           # Pixel padding around map edges
-_BACKGROUND_COLOR = (30, 30, 30)  # Dark grey background
-_ZONE_OUTLINE_COLOR = (255, 255, 255, 180)  # White outlines
+_BACKGROUND_COLOR = (245, 245, 240)  # Light warm grey background (matches app)
 _ZONE_OUTLINE_WIDTH = 2
-_PATH_COLOR = (200, 200, 100, 150)  # Yellow-ish for navigation paths
-_PATH_WIDTH = 2
+_PATH_COLOR = (180, 180, 180, 200)  # Light grey for navigation paths (matches app)
+_PATH_WIDTH = 3
 _MOW_PATH_COLOR = (100, 200, 100, 100)  # Green for mowing trails
 _MOW_PATH_WIDTH = 1
-_LABEL_COLOR = (255, 255, 255, 220)  # White text
+_LABEL_COLOR = (60, 60, 60, 255)  # Dark text on light background
 _FORBIDDEN_COLOR = (200, 50, 50, 120)  # Red for no-go zones
 
-# Zone fill colors — distinct colors for up to 8 zones, cycling after
+# Zone fill colors — soft pastels matching the Dreame app palette
 _ZONE_COLORS = [
-    (76, 153, 0, 140),    # Green
-    (0, 128, 128, 140),   # Teal
-    (0, 102, 204, 140),   # Blue
-    (153, 102, 0, 140),   # Brown
-    (102, 51, 153, 140),  # Purple
-    (204, 102, 0, 140),   # Orange
-    (0, 153, 153, 140),   # Cyan
-    (153, 153, 0, 140),   # Olive
+    ((164, 210, 145, 200), (134, 190, 115, 255)),  # Green (fill, outline)
+    ((160, 200, 220, 200), (130, 170, 200, 255)),   # Blue
+    ((240, 200, 170, 200), (220, 175, 140, 255)),   # Beige/tan
+    ((240, 180, 180, 200), (220, 150, 150, 255)),   # Pink/salmon
+    ((230, 220, 160, 200), (210, 200, 130, 255)),   # Yellow
+    ((190, 170, 220, 200), (170, 145, 200, 255)),   # Purple
+    ((170, 215, 210, 200), (140, 195, 190, 255)),   # Teal
+    ((220, 190, 160, 200), (200, 165, 130, 255)),   # Warm brown
 ]
 
 
@@ -104,20 +103,31 @@ class MowerVectorMapRenderer:
         draw = ImageDraw.Draw(image)
 
         def to_pixel(x: int, y: int) -> tuple[int, int]:
-            """Convert map coordinates to pixel coordinates."""
+            """Convert map coordinates to pixel coordinates.
+
+            Map coordinates: Y increases upward (north).
+            Pixel coordinates: Y increases downward.
+            No flip needed — higher Y values in map coords should appear
+            higher (lower pixel Y) on screen, so we invert.
+            """
             px = int((x - boundary.x1) * scale) + _PADDING
-            # Flip Y axis — map coords have Y increasing downward,
-            # but we want Y=0 at top of image for natural "north up" view
-            py = img_h - (int((y - boundary.y1) * scale) + _PADDING)
+            py = int((y - boundary.y1) * scale) + _PADDING
             return (px, py)
+
+        # Load font for labels — try larger size first
+        try:
+            font = ImageFont.load_default(size=16)
+        except TypeError:
+            # Older Pillow without size param
+            font = ImageFont.load_default()
 
         # 1. Draw zone fills
         for i, zone in enumerate(vmap.zones):
             if len(zone.path) < 3:
                 continue
-            color = _ZONE_COLORS[i % len(_ZONE_COLORS)]
+            fill_color, outline_color = _ZONE_COLORS[i % len(_ZONE_COLORS)]
             polygon = [to_pixel(x, y) for x, y in zone.path]
-            draw.polygon(polygon, fill=color, outline=_ZONE_OUTLINE_COLOR, width=_ZONE_OUTLINE_WIDTH)
+            draw.polygon(polygon, fill=fill_color, outline=outline_color, width=_ZONE_OUTLINE_WIDTH)
 
         # 2. Draw forbidden areas
         for zone in vmap.forbidden_areas:
@@ -149,20 +159,8 @@ class MowerVectorMapRenderer:
             cx = sum(x for x, y in zone.path) // len(zone.path)
             cy = sum(y for x, y in zone.path) // len(zone.path)
             px, py = to_pixel(cx, cy)
-            # Draw label with area
+            # Draw label (name only, clean like the app)
             label = zone.name
-            if zone.area > 0:
-                label += f"\n{zone.area:.0f}m\u00b2"
-            try:
-                font = ImageFont.load_default()
-            except Exception:
-                font = None
-            bbox = draw.textbbox((px, py), label, font=font, anchor="mm")
-            # Draw background rectangle for readability
-            draw.rectangle(
-                [bbox[0] - 3, bbox[1] - 2, bbox[2] + 3, bbox[3] + 2],
-                fill=(0, 0, 0, 160),
-            )
             draw.text((px, py), label, fill=_LABEL_COLOR, font=font, anchor="mm")
 
         return image

--- a/custom_components/dreame_mower/dreame/map_renderer.py
+++ b/custom_components/dreame_mower/dreame/map_renderer.py
@@ -1,0 +1,168 @@
+"""Vector polygon map renderer for Dreame mower.
+
+Renders MowerVectorMap data (zone polygons, paths, mowing trails) into
+PNG images using PIL. This is a standalone renderer that does NOT use the
+existing DreameMowerMapRenderer (which expects pixel-grid/bitmap data).
+"""
+import io
+import logging
+from PIL import Image, ImageDraw, ImageFont
+
+from .types import MowerVectorMap
+
+_LOGGER = logging.getLogger(__name__)
+
+# Rendering constants
+_MAX_IMAGE_SIZE = 2048  # Max pixels on longest side
+_MIN_IMAGE_SIZE = 400   # Min pixels on longest side
+_PADDING = 40           # Pixel padding around map edges
+_BACKGROUND_COLOR = (30, 30, 30)  # Dark grey background
+_ZONE_OUTLINE_COLOR = (255, 255, 255, 180)  # White outlines
+_ZONE_OUTLINE_WIDTH = 2
+_PATH_COLOR = (200, 200, 100, 150)  # Yellow-ish for navigation paths
+_PATH_WIDTH = 2
+_MOW_PATH_COLOR = (100, 200, 100, 100)  # Green for mowing trails
+_MOW_PATH_WIDTH = 1
+_LABEL_COLOR = (255, 255, 255, 220)  # White text
+_FORBIDDEN_COLOR = (200, 50, 50, 120)  # Red for no-go zones
+
+# Zone fill colors — distinct colors for up to 8 zones, cycling after
+_ZONE_COLORS = [
+    (76, 153, 0, 140),    # Green
+    (0, 128, 128, 140),   # Teal
+    (0, 102, 204, 140),   # Blue
+    (153, 102, 0, 140),   # Brown
+    (102, 51, 153, 140),  # Purple
+    (204, 102, 0, 140),   # Orange
+    (0, 153, 153, 140),   # Cyan
+    (153, 153, 0, 140),   # Olive
+]
+
+
+class MowerVectorMapRenderer:
+    """Renders MowerVectorMap to PNG images."""
+
+    def __init__(self) -> None:
+        self._cached_image: bytes | None = None
+        self._cached_last_updated: float | None = None
+        self.render_complete: bool = True
+
+    def render(self, vector_map: MowerVectorMap | None) -> bytes | None:
+        """Render a MowerVectorMap to PNG bytes.
+
+        Args:
+            vector_map: The vector map data to render.
+
+        Returns:
+            PNG image as bytes, or None if map data is invalid.
+        """
+        if vector_map is None:
+            return None
+
+        if not vector_map.boundary:
+            _LOGGER.debug("No boundary in vector map, cannot render")
+            return None
+
+        # Cache check
+        if (self._cached_image is not None
+                and self._cached_last_updated == vector_map.last_updated):
+            return self._cached_image
+
+        self.render_complete = False
+        try:
+            image = self._render_to_image(vector_map)
+            buf = io.BytesIO()
+            image.save(buf, format="PNG")
+            self._cached_image = buf.getvalue()
+            self._cached_last_updated = vector_map.last_updated
+            return self._cached_image
+        finally:
+            self.render_complete = True
+
+    def _render_to_image(self, vmap: MowerVectorMap) -> Image.Image:
+        """Render vector map data to a PIL Image."""
+        boundary = vmap.boundary
+
+        # Calculate image dimensions preserving aspect ratio
+        map_w = boundary.width
+        map_h = boundary.height
+
+        if map_w == 0 or map_h == 0:
+            return Image.new("RGBA", (100, 100), _BACKGROUND_COLOR)
+
+        scale = min(
+            (_MAX_IMAGE_SIZE - 2 * _PADDING) / max(map_w, 1),
+            (_MAX_IMAGE_SIZE - 2 * _PADDING) / max(map_h, 1),
+        )
+        # Ensure minimum size
+        scale = max(scale, _MIN_IMAGE_SIZE / max(map_w, map_h, 1))
+
+        img_w = int(map_w * scale) + 2 * _PADDING
+        img_h = int(map_h * scale) + 2 * _PADDING
+
+        image = Image.new("RGBA", (img_w, img_h), _BACKGROUND_COLOR)
+        draw = ImageDraw.Draw(image)
+
+        def to_pixel(x: int, y: int) -> tuple[int, int]:
+            """Convert map coordinates to pixel coordinates."""
+            px = int((x - boundary.x1) * scale) + _PADDING
+            # Flip Y axis — map coords have Y increasing downward,
+            # but we want Y=0 at top of image for natural "north up" view
+            py = img_h - (int((y - boundary.y1) * scale) + _PADDING)
+            return (px, py)
+
+        # 1. Draw zone fills
+        for i, zone in enumerate(vmap.zones):
+            if len(zone.path) < 3:
+                continue
+            color = _ZONE_COLORS[i % len(_ZONE_COLORS)]
+            polygon = [to_pixel(x, y) for x, y in zone.path]
+            draw.polygon(polygon, fill=color, outline=_ZONE_OUTLINE_COLOR, width=_ZONE_OUTLINE_WIDTH)
+
+        # 2. Draw forbidden areas
+        for zone in vmap.forbidden_areas:
+            if len(zone.path) < 3:
+                continue
+            polygon = [to_pixel(x, y) for x, y in zone.path]
+            draw.polygon(polygon, fill=_FORBIDDEN_COLOR, outline=(200, 50, 50, 220), width=2)
+
+        # 3. Draw mowing paths (trails)
+        for mow_path in vmap.mow_paths:
+            for segment in mow_path.segments:
+                if len(segment) < 2:
+                    continue
+                points = [to_pixel(x, y) for x, y in segment]
+                draw.line(points, fill=_MOW_PATH_COLOR, width=_MOW_PATH_WIDTH)
+
+        # 4. Draw navigation paths between zones
+        for path in vmap.paths:
+            if len(path.path) < 2:
+                continue
+            points = [to_pixel(x, y) for x, y in path.path]
+            draw.line(points, fill=_PATH_COLOR, width=_PATH_WIDTH)
+
+        # 5. Draw zone labels
+        for zone in vmap.zones:
+            if not zone.name or len(zone.path) < 3:
+                continue
+            # Calculate centroid for label placement
+            cx = sum(x for x, y in zone.path) // len(zone.path)
+            cy = sum(y for x, y in zone.path) // len(zone.path)
+            px, py = to_pixel(cx, cy)
+            # Draw label with area
+            label = zone.name
+            if zone.area > 0:
+                label += f"\n{zone.area:.0f}m\u00b2"
+            try:
+                font = ImageFont.load_default()
+            except Exception:
+                font = None
+            bbox = draw.textbbox((px, py), label, font=font, anchor="mm")
+            # Draw background rectangle for readability
+            draw.rectangle(
+                [bbox[0] - 3, bbox[1] - 2, bbox[2] + 3, bbox[3] + 2],
+                fill=(0, 0, 0, 160),
+            )
+            draw.text((px, py), label, fill=_LABEL_COLOR, font=font, anchor="mm")
+
+        return image

--- a/custom_components/dreame_mower/dreame/map_renderer.py
+++ b/custom_components/dreame_mower/dreame/map_renderer.py
@@ -20,8 +20,8 @@ _BACKGROUND_COLOR = (245, 245, 240)  # Light warm grey background (matches app)
 _ZONE_OUTLINE_WIDTH = 2
 _PATH_COLOR = (180, 180, 180, 200)  # Light grey for navigation paths (matches app)
 _PATH_WIDTH = 3
-_MOW_PATH_COLOR = (100, 200, 100, 100)  # Green for mowing trails
-_MOW_PATH_WIDTH = 1
+_MOW_PATH_COLOR = (50, 120, 50, 180)  # Dark green for mowing trails
+_MOW_PATH_WIDTH = 2
 _LABEL_COLOR = (60, 60, 60, 255)  # Dark text on light background
 _FORBIDDEN_COLOR = (200, 50, 50, 120)  # Red for no-go zones
 

--- a/custom_components/dreame_mower/dreame/map_renderer.py
+++ b/custom_components/dreame_mower/dreame/map_renderer.py
@@ -112,12 +112,24 @@ class MowerVectorMapRenderer:
             py = int((y - boundary.y1) * scale) + _PADDING
             return (px, py)
 
-        # Load font for labels — try larger size first
-        try:
-            font = ImageFont.load_default(size=16)
-        except TypeError:
-            # Older Pillow without size param
-            font = ImageFont.load_default()
+        # Load font for labels
+        font = None
+        for font_path in [
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",      # Linux/Docker
+            "/usr/share/fonts/truetype/freefont/FreeSans.ttf",       # Linux alt
+            "/System/Library/Fonts/Helvetica.ttc",                    # macOS
+            "/System/Library/Fonts/SFCompact.ttf",                    # macOS alt
+        ]:
+            try:
+                font = ImageFont.truetype(font_path, size=48)
+                break
+            except (OSError, IOError):
+                continue
+        if font is None:
+            try:
+                font = ImageFont.load_default(size=40)
+            except TypeError:
+                font = ImageFont.load_default()
 
         # 1. Draw zone fills
         for i, zone in enumerate(vmap.zones):
@@ -157,8 +169,10 @@ class MowerVectorMapRenderer:
             cx = sum(x for x, y in zone.path) // len(zone.path)
             cy = sum(y for x, y in zone.path) // len(zone.path)
             px, py = to_pixel(cx, cy)
-            # Draw label (name only, clean like the app)
             label = zone.name
+            # Subtle white shadow for readability on colored zones
+            for dx, dy in [(-2, -2), (-2, 2), (2, -2), (2, 2), (-2, 0), (2, 0), (0, -2), (0, 2)]:
+                draw.text((px + dx, py + dy), label, fill=(255, 255, 255, 120), font=font, anchor="mm")
             draw.text((px, py), label, fill=_LABEL_COLOR, font=font, anchor="mm")
 
         return image

--- a/custom_components/dreame_mower/dreame/types.py
+++ b/custom_components/dreame_mower/dreame/types.py
@@ -2852,3 +2852,65 @@ class MapRendererData:
     work_status: int = 0
     resources: MapRendererResources = None
     version: int = 1
+
+
+class MowerZone:
+    """A mowing zone defined by a polygon boundary."""
+    def __init__(self, zone_id: int, path: list, name: str = "", zone_type: int = 0,
+                 shape_type: int = 0, area: float = 0, time: int = 0, etime: int = 0) -> None:
+        self.zone_id = zone_id
+        self.path = path  # list of (x, y) tuples
+        self.name = name
+        self.zone_type = zone_type
+        self.shape_type = shape_type
+        self.area = area
+        self.time = time
+        self.etime = etime
+
+
+class MowerPath:
+    """A navigation path between zones."""
+    def __init__(self, path_id: int, path: list, path_type: int = 0) -> None:
+        self.path_id = path_id
+        self.path = path  # list of (x, y) tuples
+        self.path_type = path_type
+
+
+class MowerMapBoundary:
+    """Bounding box for the entire map."""
+    def __init__(self, x1: int, y1: int, x2: int, y2: int) -> None:
+        self.x1 = x1
+        self.y1 = y1
+        self.x2 = x2
+        self.y2 = y2
+
+    @property
+    def width(self) -> int:
+        return self.x2 - self.x1
+
+    @property
+    def height(self) -> int:
+        return self.y2 - self.y1
+
+
+class MowerMowPath:
+    """Mowing path trace for a zone — the actual trail the mower followed."""
+    def __init__(self, zone_id: int, segments: list) -> None:
+        self.zone_id = zone_id
+        self.segments = segments  # list of lists of (x, y) tuples, split on sentinel
+
+
+class MowerVectorMap:
+    """Complete vector map data for a mower, fetched from batch API."""
+    def __init__(self) -> None:
+        self.zones: list[MowerZone] = []
+        self.forbidden_areas: list[MowerZone] = []
+        self.paths: list[MowerPath] = []
+        self.contours: list = []
+        self.obstacles: list = []
+        self.boundary: MowerMapBoundary | None = None
+        self.total_area: float = 0
+        self.name: str = ""
+        self.map_index: int = 0
+        self.mow_paths: list[MowerMowPath] = []
+        self.last_updated: float | None = None

--- a/custom_components/dreame_mower/manifest.json
+++ b/custom_components/dreame_mower/manifest.json
@@ -18,5 +18,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "v0.0.5-alpha"
+  "version": "v0.0.8-alpha"
 }

--- a/docs/plans/2026-02-24-mower-map-rendering.md
+++ b/docs/plans/2026-02-24-mower-map-rendering.md
@@ -1,0 +1,1235 @@
+# Mower Map Rendering Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Render the mower's vector/polygon map data in Home Assistant via the existing camera entity, by fetching map data from the Dreame cloud batch API and drawing zone polygons with PIL.
+
+**Architecture:** The mower stores map data as vector polygons (zone boundaries, paths, contours) in the Dreame cloud `get_batch_device_datas` API, split across `MAP.0`-`MAP.N` keys. We add a new fetch+parse pipeline that reassembles these chunks into structured polygon data, then render it with PIL into PNG images served through the existing camera entity. The existing binary pixel-based decoder is bypassed entirely — this is a parallel data path.
+
+**Tech Stack:** Python, PIL/Pillow (already a dependency), existing `DreameMowerDreameHomeCloudProtocol.get_batch_device_datas()`, existing camera entity infrastructure.
+
+---
+
+## Background: Map Data Format
+
+The batch API returns data split across numbered keys:
+- `MAP.0` through `MAP.N` — chunks of one large JSON string. Concatenate in numeric order to get: `["<json_map_0>", "<json_map_1>"]`
+- `M_PATH.0` through `M_PATH.N` — mowing path coordinate arrays per zone
+- `SETTINGS.0` through `SETTINGS.N` — per-zone mowing settings JSON
+- `MAP.info`, `M_PATH.info`, `SETTINGS.info` — metadata (counts/versions)
+
+Each map JSON object contains:
+```json
+{
+  "mowingAreas": {"dataType": "Map", "value": [[id, {"id": 1, "type": 0, "shapeType": 0, "path": [{"x": ..., "y": ...}, ...], "name": "Backyard", "time": 566, "area": 15.7}], ...]},
+  "forbiddenAreas": {"dataType": "Map", "value": [...]},
+  "paths": {"dataType": "Map", "value": [[id, {"id": 201, "type": 1, "path": [...]}], ...]},
+  "contours": {"dataType": "Map", "value": [...]},
+  "obstacles": {"dataType": "Map", "value": [...]},
+  "boundary": {"x1": -15160, "y1": -29010, "x2": 4900, "y2": 5200},
+  "totalArea": 157,
+  "name": "",
+  "cut": [[1,6],[6,7]],
+  "mapIndex": 0,
+  "hasBack": 1
+}
+```
+
+Coordinates are in centimeters (roughly -15000 to +5000 range). Zone polygons have 10-40 vertices. The `[32767, -32768]` sentinel in M_PATH data marks path segment breaks.
+
+---
+
+### Task 1: Add Vector Map Data Types
+
+**Files:**
+- Modify: `custom_components/dreame_mower/dreame/types.py` (append to end)
+
+**Step 1: Add the new data classes**
+
+Add these classes at the end of `types.py`, before any trailing blank lines:
+
+```python
+class MowerZone:
+    """A mowing zone defined by a polygon boundary."""
+    def __init__(self, zone_id: int, path: list, name: str = "", zone_type: int = 0,
+                 shape_type: int = 0, area: float = 0, time: int = 0, etime: int = 0) -> None:
+        self.zone_id = zone_id
+        self.path = path  # list of (x, y) tuples
+        self.name = name
+        self.zone_type = zone_type
+        self.shape_type = shape_type
+        self.area = area
+        self.time = time
+        self.etime = etime
+
+
+class MowerPath:
+    """A navigation path between zones."""
+    def __init__(self, path_id: int, path: list, path_type: int = 0) -> None:
+        self.path_id = path_id
+        self.path = path  # list of (x, y) tuples
+        self.path_type = path_type
+
+
+class MowerMapBoundary:
+    """Bounding box for the entire map."""
+    def __init__(self, x1: int, y1: int, x2: int, y2: int) -> None:
+        self.x1 = x1
+        self.y1 = y1
+        self.x2 = x2
+        self.y2 = y2
+
+    @property
+    def width(self) -> int:
+        return self.x2 - self.x1
+
+    @property
+    def height(self) -> int:
+        return self.y2 - self.y1
+
+
+class MowerMowPath:
+    """Mowing path trace for a zone — the actual trail the mower followed."""
+    def __init__(self, zone_id: int, segments: list) -> None:
+        self.zone_id = zone_id
+        self.segments = segments  # list of lists of (x, y) tuples, split on sentinel
+
+
+class MowerVectorMap:
+    """Complete vector map data for a mower, fetched from batch API."""
+    def __init__(self) -> None:
+        self.zones: list[MowerZone] = []
+        self.forbidden_areas: list[MowerZone] = []
+        self.paths: list[MowerPath] = []
+        self.contours: list = []
+        self.obstacles: list = []
+        self.boundary: MowerMapBoundary | None = None
+        self.total_area: float = 0
+        self.name: str = ""
+        self.map_index: int = 0
+        self.mow_paths: list[MowerMowPath] = []
+        self.last_updated: float | None = None
+```
+
+**Step 2: Verify no syntax errors**
+
+Run: `python -c "import ast; ast.parse(open('custom_components/dreame_mower/dreame/types.py').read()); print('OK')"`
+Expected: `OK`
+
+**Step 3: Commit**
+
+```bash
+git add custom_components/dreame_mower/dreame/types.py
+git commit -m "feat: add vector map data types for mower map rendering"
+```
+
+---
+
+### Task 2: Implement Batch Map Data Parser
+
+**Files:**
+- Create: `custom_components/dreame_mower/dreame/map_data_parser.py`
+- Create: `tests/test_map_data_parser.py`
+
+This is a pure-data module with no dependencies on HA or the protocol layer — easy to test in isolation.
+
+**Step 1: Write failing tests**
+
+Create `tests/test_map_data_parser.py`:
+
+```python
+"""Tests for mower vector map data parser."""
+import json
+import pytest
+
+from custom_components.dreame_mower.dreame.map_data_parser import (
+    reassemble_map_chunks,
+    parse_mower_map,
+    parse_mow_paths,
+)
+from custom_components.dreame_mower.dreame.types import MowerVectorMap
+
+
+# --- reassemble_map_chunks tests ---
+
+def test_reassemble_single_chunk():
+    batch = {"MAP.0": '["{\\"hello\\":\\"world\\"}"]', "MAP.info": "1"}
+    result = reassemble_map_chunks(batch, "MAP")
+    assert result == '["{\\\"hello\\\":\\\"world\\\"}"]'
+
+
+def test_reassemble_multiple_chunks_ordered():
+    batch = {"MAP.0": "abc", "MAP.1": "def", "MAP.2": "ghi", "MAP.info": "1"}
+    result = reassemble_map_chunks(batch, "MAP")
+    assert result == "abcdefghi"
+
+
+def test_reassemble_skips_info_key():
+    batch = {"MAP.0": "hello", "MAP.info": "999"}
+    result = reassemble_map_chunks(batch, "MAP")
+    assert result == "hello"
+
+
+def test_reassemble_empty_batch():
+    result = reassemble_map_chunks({}, "MAP")
+    assert result is None
+
+
+def test_reassemble_no_matching_keys():
+    batch = {"SETTINGS.0": "data"}
+    result = reassemble_map_chunks(batch, "MAP")
+    assert result is None
+
+
+# --- parse_mower_map tests ---
+
+MINIMAL_MAP_JSON = json.dumps({
+    "mowingAreas": {"dataType": "Map", "value": [
+        [1, {"id": 1, "type": 0, "shapeType": 0,
+             "path": [{"x": 0, "y": 0}, {"x": 100, "y": 0}, {"x": 100, "y": 100}, {"x": 0, "y": 100}],
+             "name": "Front Yard", "time": 120, "etime": 90, "area": 10.5}]
+    ]},
+    "forbiddenAreas": {"dataType": "Map", "value": []},
+    "paths": {"dataType": "Map", "value": [
+        [201, {"id": 201, "type": 1, "shapeType": 0,
+               "path": [{"x": 50, "y": 50}, {"x": 200, "y": 200}]}]
+    ]},
+    "spotAreas": {"dataType": "Map", "value": []},
+    "cleanPoints": {"dataType": "Map", "value": []},
+    "cruisePoints": {"dataType": "Map", "value": []},
+    "obstacles": {"dataType": "Map", "value": []},
+    "contours": {"dataType": "Map", "value": []},
+    "notObsAreas": {"dataType": "Map", "value": []},
+    "md5sum": "abc123",
+    "totalArea": 10,
+    "boundary": {"x1": -100, "y1": -100, "x2": 200, "y2": 200},
+    "name": "",
+    "cut": [],
+    "merged": False,
+    "mapIndex": 0,
+    "hasBack": 1,
+})
+
+
+def test_parse_mower_map_zones():
+    result = parse_mower_map(MINIMAL_MAP_JSON)
+    assert isinstance(result, MowerVectorMap)
+    assert len(result.zones) == 1
+    assert result.zones[0].zone_id == 1
+    assert result.zones[0].name == "Front Yard"
+    assert result.zones[0].area == 10.5
+    assert len(result.zones[0].path) == 4
+    assert result.zones[0].path[0] == (0, 0)
+    assert result.zones[0].path[2] == (100, 100)
+
+
+def test_parse_mower_map_boundary():
+    result = parse_mower_map(MINIMAL_MAP_JSON)
+    assert result.boundary is not None
+    assert result.boundary.x1 == -100
+    assert result.boundary.y2 == 200
+    assert result.boundary.width == 300
+    assert result.boundary.height == 300
+
+
+def test_parse_mower_map_paths():
+    result = parse_mower_map(MINIMAL_MAP_JSON)
+    assert len(result.paths) == 1
+    assert result.paths[0].path_id == 201
+    assert result.paths[0].path[0] == (50, 50)
+
+
+def test_parse_mower_map_total_area():
+    result = parse_mower_map(MINIMAL_MAP_JSON)
+    assert result.total_area == 10
+
+
+# --- parse_mow_paths tests ---
+
+def test_parse_mow_paths_empty():
+    batch = {"M_PATH.0": "[]", "M_PATH.info": "1"}
+    result = parse_mow_paths(batch)
+    assert len(result) == 0 or (len(result) == 1 and len(result[0].segments) == 0)
+
+
+def test_parse_mow_paths_with_sentinel():
+    batch = {
+        "M_PATH.1": "[10,20],[30,40],[32767,-32768],[50,60],[70,80]",
+        "M_PATH.info": "1",
+    }
+    result = parse_mow_paths(batch)
+    assert len(result) >= 1
+    # Should have segments split on sentinel
+    mow_path = result[0]
+    assert len(mow_path.segments) == 2
+    assert mow_path.segments[0] == [(10, 20), (30, 40)]
+    assert mow_path.segments[1] == [(50, 60), (70, 80)]
+```
+
+**Step 2: Create a minimal conftest so imports work**
+
+Create `tests/conftest.py`:
+
+```python
+"""Test configuration."""
+import sys
+from pathlib import Path
+
+# Add the custom_components directory to the path so imports work
+sys.path.insert(0, str(Path(__file__).parent.parent))
+```
+
+**Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/ben/dev/Personal/dreame-mower && python -m pytest tests/test_map_data_parser.py -v 2>&1 | head -30`
+Expected: ERRORS — `ModuleNotFoundError` because `map_data_parser` doesn't exist yet
+
+**Step 4: Implement the parser**
+
+Create `custom_components/dreame_mower/dreame/map_data_parser.py`:
+
+```python
+"""Parser for mower vector map data from the Dreame batch device data API.
+
+The batch API returns map data split across numbered keys (MAP.0, MAP.1, ...).
+These chunks must be concatenated in numeric order to form a complete JSON string.
+The JSON contains polygon-based zone boundaries, navigation paths, and metadata.
+"""
+import json
+import logging
+import re
+import time
+
+from .types import (
+    MowerMapBoundary,
+    MowerMowPath,
+    MowerPath,
+    MowerVectorMap,
+    MowerZone,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Sentinel value in M_PATH data marking a path segment break
+_PATH_SENTINEL = (32767, -32768)
+
+
+def reassemble_map_chunks(batch_data: dict, prefix: str) -> str | None:
+    """Reassemble chunked data from batch API into a single string.
+
+    Keys like MAP.0, MAP.1, ... MAP.N are concatenated in numeric order.
+    The MAP.info key is skipped (it's metadata, not map content).
+
+    Args:
+        batch_data: dict from get_batch_device_datas response
+        prefix: key prefix to match, e.g. "MAP" or "M_PATH"
+
+    Returns:
+        Concatenated string, or None if no matching keys found.
+    """
+    pattern = re.compile(rf"^{re.escape(prefix)}\.(\d+)$")
+    chunks = []
+    for key, value in batch_data.items():
+        match = pattern.match(key)
+        if match:
+            chunks.append((int(match.group(1)), value))
+
+    if not chunks:
+        return None
+
+    chunks.sort(key=lambda x: x[0])
+    return "".join(value for _, value in chunks)
+
+
+def _parse_polygon_list(data_map: dict) -> list:
+    """Parse a dataType:Map structure containing polygon entries."""
+    if not data_map or data_map.get("dataType") != "Map":
+        return []
+    return data_map.get("value", [])
+
+
+def _extract_path_coords(path_list: list) -> list[tuple[int, int]]:
+    """Convert [{"x": ..., "y": ...}, ...] to [(x, y), ...]."""
+    return [(p["x"], p["y"]) for p in path_list]
+
+
+def parse_mower_map(map_json_str: str) -> MowerVectorMap:
+    """Parse a single map JSON string into a MowerVectorMap.
+
+    Args:
+        map_json_str: JSON string for one map (after unescaping from the chunk array).
+
+    Returns:
+        MowerVectorMap with zones, paths, boundary, etc.
+    """
+    data = json.loads(map_json_str)
+    vmap = MowerVectorMap()
+
+    # Parse mowing area zones
+    for entry in _parse_polygon_list(data.get("mowingAreas", {})):
+        zone_id, zone_data = entry[0], entry[1]
+        vmap.zones.append(MowerZone(
+            zone_id=zone_id,
+            path=_extract_path_coords(zone_data.get("path", [])),
+            name=zone_data.get("name", ""),
+            zone_type=zone_data.get("type", 0),
+            shape_type=zone_data.get("shapeType", 0),
+            area=zone_data.get("area", 0),
+            time=zone_data.get("time", 0),
+            etime=zone_data.get("etime", 0),
+        ))
+
+    # Parse forbidden areas
+    for entry in _parse_polygon_list(data.get("forbiddenAreas", {})):
+        zone_id, zone_data = entry[0], entry[1]
+        vmap.forbidden_areas.append(MowerZone(
+            zone_id=zone_id,
+            path=_extract_path_coords(zone_data.get("path", [])),
+            name=zone_data.get("name", ""),
+            zone_type=zone_data.get("type", 0),
+        ))
+
+    # Parse navigation paths between zones
+    for entry in _parse_polygon_list(data.get("paths", {})):
+        path_id, path_data = entry[0], entry[1]
+        vmap.paths.append(MowerPath(
+            path_id=path_id,
+            path=_extract_path_coords(path_data.get("path", [])),
+            path_type=path_data.get("type", 0),
+        ))
+
+    # Parse boundary
+    boundary = data.get("boundary")
+    if boundary:
+        vmap.boundary = MowerMapBoundary(
+            x1=boundary["x1"], y1=boundary["y1"],
+            x2=boundary["x2"], y2=boundary["y2"],
+        )
+
+    vmap.total_area = data.get("totalArea", 0)
+    vmap.name = data.get("name", "")
+    vmap.map_index = data.get("mapIndex", 0)
+    vmap.last_updated = time.time()
+
+    return vmap
+
+
+def parse_mow_paths(batch_data: dict) -> list[MowerMowPath]:
+    """Parse M_PATH.* keys from batch data into MowerMowPath objects.
+
+    Each M_PATH.N key contains a coordinate array for zone N.
+    Coordinates are comma-separated pairs: [x1,y1],[x2,y2],...
+    The sentinel [32767,-32768] marks a segment break.
+
+    Args:
+        batch_data: dict from get_batch_device_datas response
+
+    Returns:
+        List of MowerMowPath objects.
+    """
+    pattern = re.compile(r"^M_PATH\.(\d+)$")
+    paths = []
+
+    for key, value in batch_data.items():
+        match = pattern.match(key)
+        if not match:
+            continue
+
+        zone_id = int(match.group(1))
+        value = value.strip()
+
+        if not value or value == "[]":
+            continue
+
+        # Parse the coordinate pairs from the string
+        # Format: [x,y],[x,y],... or just x,y,x,y,...
+        # We need to handle: ",[32767,-32768],[10,20],[30,40]"
+        # Strip leading/trailing brackets and commas
+        coords_str = value.strip("[], ")
+        if not coords_str:
+            continue
+
+        # Parse all numbers
+        numbers = re.findall(r"-?\d+", coords_str)
+        if len(numbers) % 2 != 0:
+            _LOGGER.warning("Odd number of coordinates in M_PATH.%d, skipping last", zone_id)
+            numbers = numbers[:-1]
+
+        # Build coordinate pairs, splitting on sentinel
+        segments = []
+        current_segment = []
+        for i in range(0, len(numbers), 2):
+            x, y = int(numbers[i]), int(numbers[i + 1])
+            if (x, y) == _PATH_SENTINEL:
+                if current_segment:
+                    segments.append(current_segment)
+                    current_segment = []
+            else:
+                current_segment.append((x, y))
+
+        if current_segment:
+            segments.append(current_segment)
+
+        if segments:
+            paths.append(MowerMowPath(zone_id=zone_id, segments=segments))
+
+    return paths
+
+
+def parse_batch_map_data(batch_data: dict) -> MowerVectorMap | None:
+    """Parse complete batch device data response into a MowerVectorMap.
+
+    This is the main entry point. It:
+    1. Reassembles MAP.* chunks into a full JSON string
+    2. Parses the JSON array (may contain multiple maps by mapIndex)
+    3. Returns the primary map (mapIndex 0)
+    4. Attaches mowing paths from M_PATH.* keys
+
+    Args:
+        batch_data: Full response dict from get_batch_device_datas
+
+    Returns:
+        MowerVectorMap for the primary map, or None if parsing fails.
+    """
+    if not batch_data:
+        return None
+
+    raw_map = reassemble_map_chunks(batch_data, "MAP")
+    if not raw_map:
+        _LOGGER.debug("No MAP chunks found in batch data")
+        return None
+
+    try:
+        # The reassembled string is a JSON array of JSON strings
+        map_array = json.loads(raw_map)
+    except json.JSONDecodeError:
+        _LOGGER.warning("Failed to parse reassembled MAP data as JSON")
+        return None
+
+    if not map_array:
+        return None
+
+    # Parse each map entry — they're JSON strings within the array
+    primary_map = None
+    for map_json_str in map_array:
+        try:
+            vmap = parse_mower_map(map_json_str)
+            if vmap.map_index == 0:
+                primary_map = vmap
+        except (json.JSONDecodeError, KeyError, TypeError) as ex:
+            _LOGGER.warning("Failed to parse map entry: %s", ex)
+            continue
+
+    if primary_map is None and map_array:
+        # Fall back to first entry if no mapIndex 0 found
+        try:
+            primary_map = parse_mower_map(map_array[0])
+        except (json.JSONDecodeError, KeyError, TypeError) as ex:
+            _LOGGER.warning("Failed to parse fallback map entry: %s", ex)
+            return None
+
+    if primary_map is None:
+        return None
+
+    # Attach mowing paths
+    primary_map.mow_paths = parse_mow_paths(batch_data)
+
+    return primary_map
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/ben/dev/Personal/dreame-mower && python -m pytest tests/test_map_data_parser.py -v`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add custom_components/dreame_mower/dreame/map_data_parser.py tests/conftest.py tests/test_map_data_parser.py
+git commit -m "feat: add vector map data parser for batch API response"
+```
+
+---
+
+### Task 3: Implement Vector Map Renderer
+
+**Files:**
+- Create: `custom_components/dreame_mower/dreame/map_renderer.py`
+- Create: `tests/test_map_renderer.py`
+
+A standalone PIL-based renderer that draws zone polygons onto a canvas. No dependency on the existing `DreameMowerMapRenderer` — that one expects pixel grids and segments. This one takes `MowerVectorMap` directly.
+
+**Step 1: Write failing tests**
+
+Create `tests/test_map_renderer.py`:
+
+```python
+"""Tests for mower vector map renderer."""
+import pytest
+from PIL import Image
+import io
+
+from custom_components.dreame_mower.dreame.map_renderer import MowerVectorMapRenderer
+from custom_components.dreame_mower.dreame.types import (
+    MowerVectorMap, MowerZone, MowerMapBoundary, MowerPath, MowerMowPath,
+)
+
+
+def _make_simple_map() -> MowerVectorMap:
+    """Create a simple test map with one square zone."""
+    vmap = MowerVectorMap()
+    vmap.boundary = MowerMapBoundary(x1=0, y1=0, x2=1000, y2=1000)
+    vmap.zones = [
+        MowerZone(
+            zone_id=1,
+            path=[(100, 100), (900, 100), (900, 900), (100, 900)],
+            name="Test Zone",
+            area=64.0,
+        ),
+    ]
+    vmap.last_updated = 1.0
+    return vmap
+
+
+def _make_multi_zone_map() -> MowerVectorMap:
+    """Create a map with multiple zones and a path."""
+    vmap = MowerVectorMap()
+    vmap.boundary = MowerMapBoundary(x1=0, y1=0, x2=2000, y2=1000)
+    vmap.zones = [
+        MowerZone(zone_id=1, path=[(100, 100), (900, 100), (900, 900), (100, 900)], name="Zone A", area=64.0),
+        MowerZone(zone_id=2, path=[(1100, 100), (1900, 100), (1900, 900), (1100, 900)], name="Zone B", area=64.0),
+    ]
+    vmap.paths = [
+        MowerPath(path_id=201, path=[(900, 500), (1100, 500)], path_type=1),
+    ]
+    vmap.last_updated = 1.0
+    return vmap
+
+
+class TestMowerVectorMapRenderer:
+    def test_render_returns_png_bytes(self):
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(_make_simple_map())
+        assert isinstance(result, bytes)
+        # Verify it's a valid PNG
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "PNG"
+
+    def test_render_none_returns_none(self):
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(None)
+        assert result is None
+
+    def test_render_no_boundary_returns_none(self):
+        renderer = MowerVectorMapRenderer()
+        vmap = MowerVectorMap()
+        vmap.zones = [MowerZone(zone_id=1, path=[(0, 0), (1, 0), (1, 1)], name="X")]
+        result = renderer.render(vmap)
+        assert result is None
+
+    def test_render_image_dimensions_reasonable(self):
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(_make_simple_map())
+        img = Image.open(io.BytesIO(result))
+        # Image should be at least 100x100 and at most 4096x4096
+        assert 100 <= img.width <= 4096
+        assert 100 <= img.height <= 4096
+
+    def test_render_multi_zone(self):
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(_make_multi_zone_map())
+        assert isinstance(result, bytes)
+        img = Image.open(io.BytesIO(result))
+        # Wider map should produce wider image
+        assert img.width > img.height
+
+    def test_render_with_mow_paths(self):
+        vmap = _make_simple_map()
+        vmap.mow_paths = [
+            MowerMowPath(zone_id=1, segments=[[(200, 200), (800, 200), (800, 400)]]),
+        ]
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(vmap)
+        assert isinstance(result, bytes)
+
+    def test_render_caches_when_unchanged(self):
+        renderer = MowerVectorMapRenderer()
+        vmap = _make_simple_map()
+        result1 = renderer.render(vmap)
+        result2 = renderer.render(vmap)
+        # Same object, same last_updated — should return cached
+        assert result1 is result2
+
+    def test_render_re_renders_when_updated(self):
+        renderer = MowerVectorMapRenderer()
+        vmap = _make_simple_map()
+        result1 = renderer.render(vmap)
+        vmap.last_updated = 2.0
+        result2 = renderer.render(vmap)
+        # Different last_updated — should re-render (different bytes object)
+        assert result1 is not result2
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/ben/dev/Personal/dreame-mower && python -m pytest tests/test_map_renderer.py -v 2>&1 | head -20`
+Expected: ERRORS — `ModuleNotFoundError`
+
+**Step 3: Implement the renderer**
+
+Create `custom_components/dreame_mower/dreame/map_renderer.py`:
+
+```python
+"""Vector polygon map renderer for Dreame mower.
+
+Renders MowerVectorMap data (zone polygons, paths, mowing trails) into
+PNG images using PIL. This is a standalone renderer that does NOT use the
+existing DreameMowerMapRenderer (which expects pixel-grid/bitmap data).
+"""
+import io
+import logging
+from PIL import Image, ImageDraw, ImageFont
+
+from .types import MowerVectorMap
+
+_LOGGER = logging.getLogger(__name__)
+
+# Rendering constants
+_MAX_IMAGE_SIZE = 2048  # Max pixels on longest side
+_MIN_IMAGE_SIZE = 400   # Min pixels on longest side
+_PADDING = 40           # Pixel padding around map edges
+_BACKGROUND_COLOR = (30, 30, 30)  # Dark grey background
+_ZONE_OUTLINE_COLOR = (255, 255, 255, 180)  # White outlines
+_ZONE_OUTLINE_WIDTH = 2
+_PATH_COLOR = (200, 200, 100, 150)  # Yellow-ish for navigation paths
+_PATH_WIDTH = 2
+_MOW_PATH_COLOR = (100, 200, 100, 100)  # Green for mowing trails
+_MOW_PATH_WIDTH = 1
+_LABEL_COLOR = (255, 255, 255, 220)  # White text
+_FORBIDDEN_COLOR = (200, 50, 50, 120)  # Red for no-go zones
+
+# Zone fill colors — distinct colors for up to 8 zones, cycling after
+_ZONE_COLORS = [
+    (76, 153, 0, 140),    # Green
+    (0, 128, 128, 140),   # Teal
+    (0, 102, 204, 140),   # Blue
+    (153, 102, 0, 140),   # Brown
+    (102, 51, 153, 140),  # Purple
+    (204, 102, 0, 140),   # Orange
+    (0, 153, 153, 140),   # Cyan
+    (153, 153, 0, 140),   # Olive
+]
+
+
+class MowerVectorMapRenderer:
+    """Renders MowerVectorMap to PNG images."""
+
+    def __init__(self) -> None:
+        self._cached_image: bytes | None = None
+        self._cached_last_updated: float | None = None
+        self.render_complete: bool = True
+
+    def render(self, vector_map: MowerVectorMap | None) -> bytes | None:
+        """Render a MowerVectorMap to PNG bytes.
+
+        Args:
+            vector_map: The vector map data to render.
+
+        Returns:
+            PNG image as bytes, or None if map data is invalid.
+        """
+        if vector_map is None:
+            return None
+
+        if not vector_map.boundary:
+            _LOGGER.debug("No boundary in vector map, cannot render")
+            return None
+
+        # Cache check
+        if (self._cached_image is not None
+                and self._cached_last_updated == vector_map.last_updated):
+            return self._cached_image
+
+        self.render_complete = False
+        try:
+            image = self._render_to_image(vector_map)
+            buf = io.BytesIO()
+            image.save(buf, format="PNG")
+            self._cached_image = buf.getvalue()
+            self._cached_last_updated = vector_map.last_updated
+            return self._cached_image
+        finally:
+            self.render_complete = True
+
+    def _render_to_image(self, vmap: MowerVectorMap) -> Image.Image:
+        """Render vector map data to a PIL Image."""
+        boundary = vmap.boundary
+
+        # Calculate image dimensions preserving aspect ratio
+        map_w = boundary.width
+        map_h = boundary.height
+
+        if map_w == 0 or map_h == 0:
+            return Image.new("RGBA", (100, 100), _BACKGROUND_COLOR)
+
+        scale = min(
+            (_MAX_IMAGE_SIZE - 2 * _PADDING) / max(map_w, 1),
+            (_MAX_IMAGE_SIZE - 2 * _PADDING) / max(map_h, 1),
+        )
+        # Ensure minimum size
+        scale = max(scale, _MIN_IMAGE_SIZE / max(map_w, map_h, 1))
+
+        img_w = int(map_w * scale) + 2 * _PADDING
+        img_h = int(map_h * scale) + 2 * _PADDING
+
+        image = Image.new("RGBA", (img_w, img_h), _BACKGROUND_COLOR)
+        draw = ImageDraw.Draw(image)
+
+        def to_pixel(x: int, y: int) -> tuple[int, int]:
+            """Convert map coordinates to pixel coordinates."""
+            px = int((x - boundary.x1) * scale) + _PADDING
+            # Flip Y axis — map coords have Y increasing downward,
+            # but we want Y=0 at top of image for natural "north up" view
+            py = img_h - (int((y - boundary.y1) * scale) + _PADDING)
+            return (px, py)
+
+        # 1. Draw zone fills
+        for i, zone in enumerate(vmap.zones):
+            if len(zone.path) < 3:
+                continue
+            color = _ZONE_COLORS[i % len(_ZONE_COLORS)]
+            polygon = [to_pixel(x, y) for x, y in zone.path]
+            draw.polygon(polygon, fill=color, outline=_ZONE_OUTLINE_COLOR, width=_ZONE_OUTLINE_WIDTH)
+
+        # 2. Draw forbidden areas
+        for zone in vmap.forbidden_areas:
+            if len(zone.path) < 3:
+                continue
+            polygon = [to_pixel(x, y) for x, y in zone.path]
+            draw.polygon(polygon, fill=_FORBIDDEN_COLOR, outline=(200, 50, 50, 220), width=2)
+
+        # 3. Draw mowing paths (trails)
+        for mow_path in vmap.mow_paths:
+            for segment in mow_path.segments:
+                if len(segment) < 2:
+                    continue
+                points = [to_pixel(x, y) for x, y in segment]
+                draw.line(points, fill=_MOW_PATH_COLOR, width=_MOW_PATH_WIDTH)
+
+        # 4. Draw navigation paths between zones
+        for path in vmap.paths:
+            if len(path.path) < 2:
+                continue
+            points = [to_pixel(x, y) for x, y in path.path]
+            draw.line(points, fill=_PATH_COLOR, width=_PATH_WIDTH)
+
+        # 5. Draw zone labels
+        for zone in vmap.zones:
+            if not zone.name or len(zone.path) < 3:
+                continue
+            # Calculate centroid for label placement
+            cx = sum(x for x, y in zone.path) // len(zone.path)
+            cy = sum(y for x, y in zone.path) // len(zone.path)
+            px, py = to_pixel(cx, cy)
+            # Draw label with area
+            label = zone.name
+            if zone.area > 0:
+                label += f"\n{zone.area:.0f}m\u00b2"
+            try:
+                font = ImageFont.load_default()
+            except Exception:
+                font = None
+            bbox = draw.textbbox((px, py), label, font=font, anchor="mm")
+            # Draw background rectangle for readability
+            draw.rectangle(
+                [bbox[0] - 3, bbox[1] - 2, bbox[2] + 3, bbox[3] + 2],
+                fill=(0, 0, 0, 160),
+            )
+            draw.text((px, py), label, fill=_LABEL_COLOR, font=font, anchor="mm")
+
+        return image
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/ben/dev/Personal/dreame-mower && python -m pytest tests/test_map_renderer.py -v`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add custom_components/dreame_mower/dreame/map_renderer.py tests/test_map_renderer.py
+git commit -m "feat: add vector polygon map renderer for mower zones"
+```
+
+---
+
+### Task 4: Add Batch Map Data Fetching to Map Manager
+
+**Files:**
+- Modify: `custom_components/dreame_mower/dreame/map.py` (DreameMapMowerMapManager class)
+
+This task wires the parser into the map manager so it fetches vector map data from the batch API on each update cycle.
+
+**Step 1: Add imports to map.py**
+
+At the top of `custom_components/dreame_mower/dreame/map.py`, near the existing imports (around line 1-20), add:
+
+```python
+from .map_data_parser import parse_batch_map_data
+from .types import MowerVectorMap
+```
+
+**Step 2: Add vector map storage to _init_data()**
+
+In `DreameMapMowerMapManager._init_data()` (around line 170-197), add at the end of the method body:
+
+```python
+        self._vector_map: MowerVectorMap | None = None
+```
+
+**Step 3: Add vector map property**
+
+Add a public property to `DreameMapMowerMapManager` (after `_init_data`, around line 198):
+
+```python
+    @property
+    def vector_map(self) -> MowerVectorMap | None:
+        """Get the current vector map data (for mower polygon rendering)."""
+        return self._vector_map
+```
+
+**Step 4: Add batch data fetch method**
+
+Add a new method to `DreameMapMowerMapManager` (after the `vector_map` property):
+
+```python
+    def _fetch_vector_map_from_batch_api(self) -> bool:
+        """Fetch vector map data from the batch device data API.
+
+        Requests MAP.*, M_PATH.*, and SETTINGS.* keys from the cloud
+        batch API and parses them into a MowerVectorMap.
+
+        Returns:
+            True if map data was updated, False otherwise.
+        """
+        if not self._protocol.cloud or not self._protocol.cloud.logged_in:
+            return False
+
+        try:
+            # Build the list of keys to fetch
+            keys = []
+            # MAP chunks — request up to 40 (typical is 0-32)
+            for i in range(40):
+                keys.append(f"MAP.{i}")
+            keys.append("MAP.info")
+            # M_PATH chunks
+            for i in range(10):
+                keys.append(f"M_PATH.{i}")
+            keys.append("M_PATH.info")
+            # Settings
+            for i in range(5):
+                keys.append(f"SETTINGS.{i}")
+            keys.append("SETTINGS.info")
+
+            batch_data = self._protocol.cloud.get_batch_device_datas(keys)
+            if not batch_data:
+                _LOGGER.debug("No batch data returned from cloud API")
+                return False
+
+            vector_map = parse_batch_map_data(batch_data)
+            if vector_map is None:
+                _LOGGER.debug("Failed to parse batch map data")
+                return False
+
+            self._vector_map = vector_map
+            _LOGGER.debug(
+                "Vector map updated: %d zones, %d paths, boundary=%s",
+                len(vector_map.zones),
+                len(vector_map.paths),
+                vector_map.boundary,
+            )
+            return True
+
+        except Exception as ex:
+            _LOGGER.warning("Failed to fetch vector map from batch API: %s", ex)
+            return False
+```
+
+**Step 5: Hook into the update() method**
+
+In `DreameMapMowerMapManager.update()` (around line 1195-1282), find the section that handles cloud-connected devices. Near the end of the `try` block (before the `except` on approximately line 1275), add:
+
+```python
+        # Fetch vector map data from batch API (for mower polygon rendering)
+        if self._protocol.dreame_cloud and self._protocol.cloud.connected:
+            if (self._vector_map is None
+                    or self._device_running
+                    or (self._vector_map.last_updated and time.time() - self._vector_map.last_updated > 300)):
+                if self._fetch_vector_map_from_batch_api():
+                    self._map_data_changed()
+```
+
+This fetches vector map data when:
+- No vector map exists yet (first load)
+- Device is actively running (mowing)
+- Map data is older than 5 minutes (background refresh)
+
+**Step 6: Verify syntax**
+
+Run: `python -c "import ast; ast.parse(open('custom_components/dreame_mower/dreame/map.py').read()); print('OK')"`
+Expected: `OK`
+
+**Step 7: Commit**
+
+```bash
+git add custom_components/dreame_mower/dreame/map.py
+git commit -m "feat: fetch vector map data from batch API in map manager"
+```
+
+---
+
+### Task 5: Wire Vector Map Renderer into Camera Entity
+
+**Files:**
+- Modify: `custom_components/dreame_mower/camera.py`
+- Modify: `custom_components/dreame_mower/dreame/device.py`
+
+This is the final wiring task. The camera entity needs to use the vector renderer when vector map data is available.
+
+**Step 1: Add vector map access to device.py**
+
+In `custom_components/dreame_mower/dreame/device.py`, add a property to `DreameMowerDevice` (near `get_map()` around line 1829):
+
+```python
+    @property
+    def vector_map(self):
+        """Get the current vector map data from the map manager."""
+        if self._map_manager:
+            return self._map_manager.vector_map
+        return None
+```
+
+**Step 2: Add imports to camera.py**
+
+At the top of `custom_components/dreame_mower/camera.py`, add:
+
+```python
+from .dreame.map_renderer import MowerVectorMapRenderer
+```
+
+**Step 3: Add vector renderer to DreameMowerCameraEntity.__init__()**
+
+In `DreameMowerCameraEntity.__init__()` (around line 432-509), after the existing renderer initialization (around line 490), add:
+
+```python
+        # Vector map renderer for polygon-based mower maps
+        self._vector_renderer = MowerVectorMapRenderer()
+```
+
+**Step 4: Modify _update_image to prefer vector map**
+
+In `DreameMowerCameraEntity._update_image()` (around line 776-783), replace the method body. The current code is approximately:
+
+```python
+    async def _update_image(self, map_data, robot_status, station_status) -> None:
+        self._image = self._renderer.render_map(map_data, robot_status, station_status)
+        ...
+```
+
+Replace with:
+
+```python
+    async def _update_image(self, map_data, robot_status, station_status) -> None:
+        # Prefer vector map rendering for mower polygon data
+        vector_map = self.device.vector_map if self.device else None
+        if vector_map and vector_map.boundary:
+            rendered = await self.coordinator.hass.async_add_executor_job(
+                self._vector_renderer.render, vector_map
+            )
+            if rendered:
+                self._image = rendered
+                if self._renderer._calibration_points != self._calibration_points:
+                    self._calibration_points = self._renderer._calibration_points
+                    self.coordinator.set_updated_data()
+                return
+
+        # Fall back to existing pixel-based renderer
+        self._image = self._renderer.render_map(map_data, robot_status, station_status)
+        if self._renderer._calibration_points != self._calibration_points:
+            self._calibration_points = self._renderer._calibration_points
+            self.coordinator.set_updated_data()
+```
+
+**Step 5: Verify syntax**
+
+Run the following commands:
+```bash
+python -c "import ast; ast.parse(open('custom_components/dreame_mower/camera.py').read()); print('camera OK')"
+python -c "import ast; ast.parse(open('custom_components/dreame_mower/dreame/device.py').read()); print('device OK')"
+```
+Expected: Both print OK
+
+**Step 6: Commit**
+
+```bash
+git add custom_components/dreame_mower/camera.py custom_components/dreame_mower/dreame/device.py
+git commit -m "feat: wire vector map renderer into camera entity"
+```
+
+---
+
+### Task 6: Integration Test — Manual Verification
+
+**Files:** None (verification only)
+
+**Step 1: Run the unit tests**
+
+Run: `cd /Users/ben/dev/Personal/dreame-mower && python -m pytest tests/ -v`
+Expected: All tests pass
+
+**Step 2: Verify all modified files parse correctly**
+
+```bash
+cd /Users/ben/dev/Personal/dreame-mower
+python -c "
+import ast
+files = [
+    'custom_components/dreame_mower/dreame/types.py',
+    'custom_components/dreame_mower/dreame/map_data_parser.py',
+    'custom_components/dreame_mower/dreame/map_renderer.py',
+    'custom_components/dreame_mower/dreame/map.py',
+    'custom_components/dreame_mower/dreame/device.py',
+    'custom_components/dreame_mower/camera.py',
+]
+for f in files:
+    ast.parse(open(f).read())
+    print(f'OK: {f}')
+print('All files parse successfully')
+"
+```
+Expected: All files OK
+
+**Step 3: Test the parser against real device data**
+
+Create a quick test script to verify against the actual API response captured in `device-info.txt`. This validates the parser works with real-world data shapes:
+
+```bash
+cd /Users/ben/dev/Personal/dreame-mower
+python -c "
+from custom_components.dreame_mower.dreame.map_data_parser import parse_batch_map_data
+
+# Simulate batch data with a minimal real-world-shaped response
+import json
+batch = {}
+
+# Create a realistic MAP.0 chunk
+map_data = json.dumps([json.dumps({
+    'mowingAreas': {'dataType': 'Map', 'value': [
+        [1, {'id': 1, 'type': 0, 'shapeType': 0,
+             'path': [{'x': 4900, 'y': -10750}, {'x': 4880, 'y': -10450},
+                      {'x': 4880, 'y': -9350}, {'x': 4840, 'y': -8850}],
+             'name': 'Backyard', 'time': 1288, 'etime': 966, 'area': 141}],
+    ]},
+    'forbiddenAreas': {'dataType': 'Map', 'value': []},
+    'paths': {'dataType': 'Map', 'value': []},
+    'spotAreas': {'dataType': 'Map', 'value': []},
+    'cleanPoints': {'dataType': 'Map', 'value': []},
+    'cruisePoints': {'dataType': 'Map', 'value': []},
+    'obstacles': {'dataType': 'Map', 'value': []},
+    'contours': {'dataType': 'Map', 'value': []},
+    'notObsAreas': {'dataType': 'Map', 'value': []},
+    'md5sum': 'test',
+    'totalArea': 141,
+    'boundary': {'x1': -15160, 'y1': -29010, 'x2': 4900, 'y2': 5200},
+    'name': '',
+    'cut': [],
+    'merged': False,
+    'mapIndex': 0,
+    'hasBack': 1,
+})])
+batch['MAP.0'] = map_data
+batch['MAP.info'] = '1'
+
+result = parse_batch_map_data(batch)
+print(f'Zones: {len(result.zones)}')
+print(f'Zone 1: {result.zones[0].name} ({result.zones[0].area}m²)')
+print(f'Boundary: ({result.boundary.x1},{result.boundary.y1}) to ({result.boundary.x2},{result.boundary.y2})')
+print(f'Boundary size: {result.boundary.width}x{result.boundary.height}')
+print('Parser working correctly!')
+"
+```
+Expected: Output showing zone data parsed correctly
+
+**Step 4: Test the renderer produces a viewable image**
+
+```bash
+cd /Users/ben/dev/Personal/dreame-mower
+python -c "
+from custom_components.dreame_mower.dreame.map_renderer import MowerVectorMapRenderer
+from custom_components.dreame_mower.dreame.types import (
+    MowerVectorMap, MowerZone, MowerMapBoundary, MowerPath,
+)
+import time
+
+vmap = MowerVectorMap()
+vmap.boundary = MowerMapBoundary(x1=-15160, y1=-29010, x2=4900, y2=5200)
+vmap.zones = [
+    MowerZone(1, [(4900,-10750),(4880,-10450),(4880,-9350),(4840,-8850),
+                  (4550,-5580),(3580,-4520),(1640,-4080),(1130,-2430),
+                  (1390,-810),(700,3820),(-270,4150),(-3220,4270),
+                  (-3220,1820),(-2520,-4070),(-2870,-7020),(-1620,-7170),
+                  (970,-7420),(1820,-9220),(2920,-11720),(3970,-18570)],
+                 'Backyard', area=141),
+    MowerZone(2, [(-920,-26220),(-3870,-26270),(-4270,-24920),(-2570,-23120),
+                  (470,-23520),(20,-25920),(-820,-26220)],
+                 'Front2', area=8.89),
+    MowerZone(5, [(-5790,-27450),(-11220,-27120),(-11570,-27690),
+                  (-11190,-28310),(-9860,-28500),(-5720,-27570)],
+                 'Street2', area=5.14),
+]
+vmap.paths = [
+    MowerPath(201, [(3810,-17840),(1060,-22490),(-770,-24060)], path_type=1),
+]
+vmap.last_updated = time.time()
+
+renderer = MowerVectorMapRenderer()
+png_bytes = renderer.render(vmap)
+with open('/tmp/mower_map_test.png', 'wb') as f:
+    f.write(png_bytes)
+print(f'Rendered {len(png_bytes)} bytes to /tmp/mower_map_test.png')
+print('Open the file to verify it looks correct!')
+"
+```
+Expected: PNG file at `/tmp/mower_map_test.png` that shows colored zone polygons with labels on a dark background
+
+**Step 5: Open and visually verify the test image**
+
+Run: `open /tmp/mower_map_test.png`
+Expected: See a map with colored zones labeled "Backyard", "Front2", "Street2" with area labels, and a yellow navigation path line.
+
+---
+
+## Summary of Changes
+
+| File | Change |
+|------|--------|
+| `dreame/types.py` | Add `MowerZone`, `MowerPath`, `MowerMapBoundary`, `MowerMowPath`, `MowerVectorMap` classes |
+| `dreame/map_data_parser.py` | **NEW** — Parse batch API response into `MowerVectorMap` |
+| `dreame/map_renderer.py` | **NEW** — Render `MowerVectorMap` to PNG with PIL |
+| `dreame/map.py` | Add `_vector_map` storage, `_fetch_vector_map_from_batch_api()`, hook into `update()` |
+| `dreame/device.py` | Add `vector_map` property |
+| `camera.py` | Add `MowerVectorMapRenderer`, prefer vector rendering in `_update_image()` |
+| `tests/conftest.py` | **NEW** — Test path config |
+| `tests/test_map_data_parser.py` | **NEW** — Parser unit tests |
+| `tests/test_map_renderer.py` | **NEW** — Renderer unit tests |
+
+## Future Enhancements (Not in This Plan)
+
+- SVG output via custom HTTP view for interactive maps
+- Zone-specific settings overlay (mowing height, direction)
+- Robot/charger position rendering (needs position data from device properties)
+- Contour rendering
+- Obstacle icons
+- Color scheme customization matching the existing vacuum renderer's options
+- Live mowing path updates during active mowing sessions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,72 @@
+"""Test configuration."""
+import importlib
+import importlib.abc
+import importlib.machinery
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Add the project root to the path so imports work
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class _MockModule(MagicMock):
+    """Mock module that supports attribute access and submodule imports."""
+
+    def __init__(self, *args, name="mock", **kwargs):
+        # Accept arbitrary positional args so subclassing works
+        super().__init__(**kwargs)
+        self._mock_name = name
+        self.__name__ = name
+        self.__path__ = [f"/fake/{name.replace('.', '/')}"]
+        self.__file__ = f"/fake/{name.replace('.', '/')}.py"
+        self.__all__ = []
+        self.__spec__ = None
+        self.__loader__ = None
+        self.__package__ = name
+
+
+class _CatchAllLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        return _MockModule(name=spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+class _CatchAllFinder(importlib.abc.MetaPathFinder):
+    """Auto-creates mock modules for specified top-level packages."""
+
+    def __init__(self, packages):
+        self.packages = packages
+
+    def find_spec(self, fullname, path, target=None):
+        for pkg in self.packages:
+            if fullname == pkg or fullname.startswith(pkg + "."):
+                if fullname not in sys.modules:
+                    return importlib.machinery.ModuleSpec(
+                        fullname,
+                        _CatchAllLoader(),
+                        is_package=True,
+                    )
+        return None
+
+
+# Mock all external dependencies that the dreame_mower package needs
+_MOCK_PACKAGES = [
+    "homeassistant",
+    "requests",
+    "Crypto",
+    "Cryptodome",
+    "PIL",
+    "aiohttp",
+    "cryptography",
+    "micloud",
+    "miio",
+    "numpy",
+    "paho",
+    "py_mini_racer",
+    "voluptuous",
+]
+
+sys.meta_path.insert(0, _CatchAllFinder(_MOCK_PACKAGES))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ _MOCK_PACKAGES = [
     "requests",
     "Crypto",
     "Cryptodome",
-    "PIL",
+    # "PIL" — not mocked; pillow is installed for map_renderer tests
     "aiohttp",
     "cryptography",
     "micloud",

--- a/tests/test_map_data_parser.py
+++ b/tests/test_map_data_parser.py
@@ -107,18 +107,20 @@ def test_parse_mower_map_total_area():
 # --- parse_mow_paths tests ---
 
 def test_parse_mow_paths_empty():
-    batch = {"M_PATH.0": "[]", "M_PATH.info": "1"}
+    batch = {"M_PATH.0": "[]", "M_PATH.info": "2"}
     result = parse_mow_paths(batch)
-    assert len(result) == 0 or (len(result) == 1 and len(result[0].segments) == 0)
+    assert len(result) == 0
 
 
 def test_parse_mow_paths_with_sentinel():
+    # M_PATH data is chunked: M_PATH.0 is first map (empty), rest is real data
     batch = {
+        "M_PATH.0": "[]",
         "M_PATH.1": "[10,20],[30,40],[32767,-32768],[50,60],[70,80]",
-        "M_PATH.info": "1",
+        "M_PATH.info": "2",
     }
     result = parse_mow_paths(batch)
-    assert len(result) >= 1
+    assert len(result) == 1
     # Should have segments split on sentinel
     mow_path = result[0]
     assert len(mow_path.segments) == 2

--- a/tests/test_map_data_parser.py
+++ b/tests/test_map_data_parser.py
@@ -1,0 +1,126 @@
+"""Tests for mower vector map data parser."""
+import json
+import pytest
+
+from custom_components.dreame_mower.dreame.map_data_parser import (
+    reassemble_map_chunks,
+    parse_mower_map,
+    parse_mow_paths,
+)
+from custom_components.dreame_mower.dreame.types import MowerVectorMap
+
+
+# --- reassemble_map_chunks tests ---
+
+def test_reassemble_single_chunk():
+    batch = {"MAP.0": '["{\\\"hello\\\":\\\"world\\\"}"]', "MAP.info": "1"}
+    result = reassemble_map_chunks(batch, "MAP")
+    assert result == '["{\\\"hello\\\":\\\"world\\\"}"]'
+
+
+def test_reassemble_multiple_chunks_ordered():
+    batch = {"MAP.0": "abc", "MAP.1": "def", "MAP.2": "ghi", "MAP.info": "1"}
+    result = reassemble_map_chunks(batch, "MAP")
+    assert result == "abcdefghi"
+
+
+def test_reassemble_skips_info_key():
+    batch = {"MAP.0": "hello", "MAP.info": "999"}
+    result = reassemble_map_chunks(batch, "MAP")
+    assert result == "hello"
+
+
+def test_reassemble_empty_batch():
+    result = reassemble_map_chunks({}, "MAP")
+    assert result is None
+
+
+def test_reassemble_no_matching_keys():
+    batch = {"SETTINGS.0": "data"}
+    result = reassemble_map_chunks(batch, "MAP")
+    assert result is None
+
+
+# --- parse_mower_map tests ---
+
+MINIMAL_MAP_JSON = json.dumps({
+    "mowingAreas": {"dataType": "Map", "value": [
+        [1, {"id": 1, "type": 0, "shapeType": 0,
+             "path": [{"x": 0, "y": 0}, {"x": 100, "y": 0}, {"x": 100, "y": 100}, {"x": 0, "y": 100}],
+             "name": "Front Yard", "time": 120, "etime": 90, "area": 10.5}]
+    ]},
+    "forbiddenAreas": {"dataType": "Map", "value": []},
+    "paths": {"dataType": "Map", "value": [
+        [201, {"id": 201, "type": 1, "shapeType": 0,
+               "path": [{"x": 50, "y": 50}, {"x": 200, "y": 200}]}]
+    ]},
+    "spotAreas": {"dataType": "Map", "value": []},
+    "cleanPoints": {"dataType": "Map", "value": []},
+    "cruisePoints": {"dataType": "Map", "value": []},
+    "obstacles": {"dataType": "Map", "value": []},
+    "contours": {"dataType": "Map", "value": []},
+    "notObsAreas": {"dataType": "Map", "value": []},
+    "md5sum": "abc123",
+    "totalArea": 10,
+    "boundary": {"x1": -100, "y1": -100, "x2": 200, "y2": 200},
+    "name": "",
+    "cut": [],
+    "merged": False,
+    "mapIndex": 0,
+    "hasBack": 1,
+})
+
+
+def test_parse_mower_map_zones():
+    result = parse_mower_map(MINIMAL_MAP_JSON)
+    assert isinstance(result, MowerVectorMap)
+    assert len(result.zones) == 1
+    assert result.zones[0].zone_id == 1
+    assert result.zones[0].name == "Front Yard"
+    assert result.zones[0].area == 10.5
+    assert len(result.zones[0].path) == 4
+    assert result.zones[0].path[0] == (0, 0)
+    assert result.zones[0].path[2] == (100, 100)
+
+
+def test_parse_mower_map_boundary():
+    result = parse_mower_map(MINIMAL_MAP_JSON)
+    assert result.boundary is not None
+    assert result.boundary.x1 == -100
+    assert result.boundary.y2 == 200
+    assert result.boundary.width == 300
+    assert result.boundary.height == 300
+
+
+def test_parse_mower_map_paths():
+    result = parse_mower_map(MINIMAL_MAP_JSON)
+    assert len(result.paths) == 1
+    assert result.paths[0].path_id == 201
+    assert result.paths[0].path[0] == (50, 50)
+
+
+def test_parse_mower_map_total_area():
+    result = parse_mower_map(MINIMAL_MAP_JSON)
+    assert result.total_area == 10
+
+
+# --- parse_mow_paths tests ---
+
+def test_parse_mow_paths_empty():
+    batch = {"M_PATH.0": "[]", "M_PATH.info": "1"}
+    result = parse_mow_paths(batch)
+    assert len(result) == 0 or (len(result) == 1 and len(result[0].segments) == 0)
+
+
+def test_parse_mow_paths_with_sentinel():
+    batch = {
+        "M_PATH.1": "[10,20],[30,40],[32767,-32768],[50,60],[70,80]",
+        "M_PATH.info": "1",
+    }
+    result = parse_mow_paths(batch)
+    assert len(result) >= 1
+    # Should have segments split on sentinel
+    mow_path = result[0]
+    assert len(mow_path.segments) == 2
+    assert mow_path.segments[0] == [(10, 20), (30, 40)]
+    assert mow_path.segments[1] == [(50, 60), (70, 80)]

--- a/tests/test_map_data_parser.py
+++ b/tests/test_map_data_parser.py
@@ -124,5 +124,6 @@ def test_parse_mow_paths_with_sentinel():
     # Should have segments split on sentinel
     mow_path = result[0]
     assert len(mow_path.segments) == 2
-    assert mow_path.segments[0] == [(10, 20), (30, 40)]
-    assert mow_path.segments[1] == [(50, 60), (70, 80)]
+    # Coordinates are scaled 10x (decimeters -> centimeters)
+    assert mow_path.segments[0] == [(100, 200), (300, 400)]
+    assert mow_path.segments[1] == [(500, 600), (700, 800)]

--- a/tests/test_map_renderer.py
+++ b/tests/test_map_renderer.py
@@ -1,0 +1,104 @@
+"""Tests for mower vector map renderer."""
+import pytest
+from PIL import Image
+import io
+
+from custom_components.dreame_mower.dreame.map_renderer import MowerVectorMapRenderer
+from custom_components.dreame_mower.dreame.types import (
+    MowerVectorMap, MowerZone, MowerMapBoundary, MowerPath, MowerMowPath,
+)
+
+
+def _make_simple_map() -> MowerVectorMap:
+    """Create a simple test map with one square zone."""
+    vmap = MowerVectorMap()
+    vmap.boundary = MowerMapBoundary(x1=0, y1=0, x2=1000, y2=1000)
+    vmap.zones = [
+        MowerZone(
+            zone_id=1,
+            path=[(100, 100), (900, 100), (900, 900), (100, 900)],
+            name="Test Zone",
+            area=64.0,
+        ),
+    ]
+    vmap.last_updated = 1.0
+    return vmap
+
+
+def _make_multi_zone_map() -> MowerVectorMap:
+    """Create a map with multiple zones and a path."""
+    vmap = MowerVectorMap()
+    vmap.boundary = MowerMapBoundary(x1=0, y1=0, x2=2000, y2=1000)
+    vmap.zones = [
+        MowerZone(zone_id=1, path=[(100, 100), (900, 100), (900, 900), (100, 900)], name="Zone A", area=64.0),
+        MowerZone(zone_id=2, path=[(1100, 100), (1900, 100), (1900, 900), (1100, 900)], name="Zone B", area=64.0),
+    ]
+    vmap.paths = [
+        MowerPath(path_id=201, path=[(900, 500), (1100, 500)], path_type=1),
+    ]
+    vmap.last_updated = 1.0
+    return vmap
+
+
+class TestMowerVectorMapRenderer:
+    def test_render_returns_png_bytes(self):
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(_make_simple_map())
+        assert isinstance(result, bytes)
+        # Verify it's a valid PNG
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "PNG"
+
+    def test_render_none_returns_none(self):
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(None)
+        assert result is None
+
+    def test_render_no_boundary_returns_none(self):
+        renderer = MowerVectorMapRenderer()
+        vmap = MowerVectorMap()
+        vmap.zones = [MowerZone(zone_id=1, path=[(0, 0), (1, 0), (1, 1)], name="X")]
+        result = renderer.render(vmap)
+        assert result is None
+
+    def test_render_image_dimensions_reasonable(self):
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(_make_simple_map())
+        img = Image.open(io.BytesIO(result))
+        # Image should be at least 100x100 and at most 4096x4096
+        assert 100 <= img.width <= 4096
+        assert 100 <= img.height <= 4096
+
+    def test_render_multi_zone(self):
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(_make_multi_zone_map())
+        assert isinstance(result, bytes)
+        img = Image.open(io.BytesIO(result))
+        # Wider map should produce wider image
+        assert img.width > img.height
+
+    def test_render_with_mow_paths(self):
+        vmap = _make_simple_map()
+        vmap.mow_paths = [
+            MowerMowPath(zone_id=1, segments=[[(200, 200), (800, 200), (800, 400)]]),
+        ]
+        renderer = MowerVectorMapRenderer()
+        result = renderer.render(vmap)
+        assert isinstance(result, bytes)
+
+    def test_render_caches_when_unchanged(self):
+        renderer = MowerVectorMapRenderer()
+        vmap = _make_simple_map()
+        result1 = renderer.render(vmap)
+        result2 = renderer.render(vmap)
+        # Same object, same last_updated — should return cached
+        assert result1 is result2
+
+    def test_render_re_renders_when_updated(self):
+        renderer = MowerVectorMapRenderer()
+        vmap = _make_simple_map()
+        result1 = renderer.render(vmap)
+        vmap.last_updated = 2.0
+        result2 = renderer.render(vmap)
+        # Different last_updated — should re-render (different bytes object)
+        assert result1 is not result2


### PR DESCRIPTION
After some research I discovered that the map from the mower is available on the device info endpoint. It is a vector map so is entirely different to the grid map used for the vacuums. 

Example working in HASS: 
<img width="1474" height="1608" alt="CleanShot 2026-02-24 at 20 15 50@2x" src="https://github.com/user-attachments/assets/9ed84fa7-3493-48f0-bfc2-b301fc6fe48e" />

The mower trail is also shown. I can't quite work out where this comes from, it seems to be a trail of the previous mower run, or perhaps the most recent 30 minutes of mower movement.