### PR TITLE
fix: remove deprecated config_entry assignment in OptionsFlowHandler (HA 2024.12+)

### DIFF
--- a/custom_components/dreame_mower/config_flow.py
+++ b/custom_components/dreame_mower/config_flow.py
@@ -66,10 +66,6 @@ LOCAL: Final = "Manual Connection (Without map)"
 class DreameMowerOptionsFlowHandler(OptionsFlow):
     """Handle Dreame Mower options."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize Dreame Mower options flow."""
-        self.config_entry = config_entry
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -163,7 +159,7 @@ class DreameMowerFlowHandler(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> DreameMowerOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return DreameMowerOptionsFlowHandler(config_entry)
+        return DreameMowerOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Problem

Since Home Assistant 2024.12, `config_entry` is a **read-only property** on `OptionsFlowHandler` and can no longer be assigned in `__init__`. This causes the integration's options flow (the config UI) to crash immediately:

```
File "config_flow.py", line 71, in __init__
AttributeError: property 'config_entry' of 'DreameMowerOptionsFlowHandler' object has no setter
```

Reference: [HA Developer Docs — Options Flow breaking change (2024-11-12)](https://developers.home-assistant.io/blog/2024/11/12/options-flow/)

## Fix

Two minimal changes in `config_flow.py`:

1. **Remove** the `__init__` method from `DreameMowerOptionsFlowHandler` that manually assigned `self.config_entry = config_entry` (lines ~68-71).
2. **Update** `async_get_options_flow` to call `DreameMowerOptionsFlowHandler()` with no arguments (line ~165).

The base class already injects `config_entry` automatically — the manual assignment was redundant and is now a breaking error.

## Backwards compatibility

Fully backwards-compatible: the base class has handled `config_entry` injection automatically for several HA versions. Works on both old and new HA versions.

## Testing

- Tested on **Home Assistant 2026.4.4** with a **Dreame A2** mower.
- Options flow opens without error after the fix.