### PR TITLE
fix: multiple bugs and compatibility improvements

### DIFF
--- a/custom_components/dreame_mower/camera.py
+++ b/custom_components/dreame_mower/camera.py
@@ -442,6 +442,7 @@ class DreameMowerCameraEntity(DreameMowerEntity, Camera):
     ) -> None:
         """Initialize a Dreame Mower Camera entity."""
         super().__init__(coordinator, description)
+        Camera.__init__(self)
         self._generate_entity_id(ENTITY_ID_FORMAT)
         self.content_type = PNG_CONTENT_TYPE
         self.stream = None

--- a/custom_components/dreame_mower/camera.py
+++ b/custom_components/dreame_mower/camera.py
@@ -442,7 +442,7 @@ class DreameMowerCameraEntity(DreameMowerEntity, Camera):
     ) -> None:
         """Initialize a Dreame Mower Camera entity."""
         super().__init__(coordinator, description)
-        Camera.__init__(self)
+        self._webrtc_provider = None
         self._generate_entity_id(ENTITY_ID_FORMAT)
         self.content_type = PNG_CONTENT_TYPE
         self.stream = None

--- a/custom_components/dreame_mower/config_flow.py
+++ b/custom_components/dreame_mower/config_flow.py
@@ -66,10 +66,6 @@ LOCAL: Final = "Manual Connection (Without map)"
 class DreameMowerOptionsFlowHandler(OptionsFlow):
     """Handle Dreame Mower options."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize Dreame Mower options flow."""
-        self.config_entry = config_entry
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -163,7 +159,7 @@ class DreameMowerFlowHandler(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> DreameMowerOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return DreameMowerOptionsFlowHandler(config_entry)
+        return DreameMowerOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -459,8 +455,8 @@ class DreameMowerFlowHandler(ConfigFlow, domain=DOMAIN):
                                 and len(device["customName"]) > 0
                                 else device["deviceInfo"]["displayName"]
                             )
-                            model = model_map[device["model"]]
                             modelId = device["model"]
+                            model = model_map.get(modelId, modelId)
                             list_name = f"{name} - {model} ({modelId})"
                             self.devices[list_name] = device
 

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -198,6 +198,7 @@ class DreameMowerDevice:
         self._dirty_data: dict[DreameMowerProperty, DirtyData] = {}
         self._dirty_auto_switch_data: dict[DreameMowerAutoSwitchProperty, DirtyData] = {}
         self._dirty_ai_data: dict[DreameMowerStrAIProperty | DreameMowerAIProperty, Any] = None
+        self._siid_piid_to_did = None
         self._discard_timeout = 5
         self._restore_timeout = 15
 
@@ -351,13 +352,36 @@ class DreameMowerDevice:
 
                 self._handle_properties(params)
 
+    def _build_siid_piid_map(self):
+        """Build reverse mapping from (siid, piid) to DreameMowerProperty value."""
+        if self._siid_piid_to_did is None:
+            self._siid_piid_to_did = {}
+            for prop, mapping in self.property_mapping.items():
+                if "aiid" not in mapping:
+                    key = (mapping["siid"], mapping["piid"])
+                    if key not in self._siid_piid_to_did:
+                        self._siid_piid_to_did[key] = prop.value
+        return self._siid_piid_to_did
+
     def _handle_properties(self, properties) -> bool:
         changed = False
         callbacks = []
+        siid_piid_map = self._build_siid_piid_map()
         for prop in properties:
             if not isinstance(prop, dict):
                 continue
             did = int(prop["did"])
+            try:
+                DreameMowerProperty(did)
+            except ValueError:
+                siid = prop.get("siid")
+                piid = prop.get("piid")
+                if siid is not None and piid is not None and (siid, piid) in siid_piid_map:
+                    did = siid_piid_map[(siid, piid)]
+                    _LOGGER.debug("Resolved property via siid/piid (%s.%s) -> %s", siid, piid, DreameMowerProperty(did).name)
+                else:
+                    _LOGGER.debug("Skipping unknown property ID %s (siid=%s, piid=%s)", did, prop.get("siid"), prop.get("piid"))
+                    continue
             if prop["code"] == 0 and "value" in prop:
                 value = prop["value"]
                 if did in self._dirty_data:
@@ -1301,7 +1325,7 @@ class DreameMowerDevice:
 
     def schedule_update(self, wait: float = None, force_request_properties=False) -> None:
         """Schedule a device update for future"""
-        if wait == None:
+        if wait is None:
             wait = self._update_interval
 
         if self._update_timer is not None:
@@ -1800,7 +1824,7 @@ class DreameMowerDevice:
                 render_map_data.saved_map_status = 2
 
             if (
-                render_map_data.charger_position == None
+                render_map_data.charger_position is None
                 and render_map_data.docked
                 and render_map_data.robot_position
                 and not render_map_data.saved_map
@@ -2511,14 +2535,14 @@ class DreameMowerDevice:
         if self._map_manager:
             self._map_manager.editor.set_cruise_points([])
 
-        # if self.status.started:
         if not self.status.docked:
             self._update_property(DreameMowerProperty.STATUS, DreameMowerStatus.BACK_HOME.value)
             self._update_property(DreameMowerProperty.STATE, DreameMowerState.RETURNING.value)
 
-        # Clear active segments on current map data
-        # if self._map_manager:
-        #    self._map_manager.editor.set_active_segments([])
+        if self.status.started:
+            self._update_status(DreameMowerTaskStatus.COMPLETED, DreameMowerStatus.BACK_HOME)
+            if self._map_manager:
+                self._map_manager.editor.set_active_segments([])
 
         if not self.capability.cruising:
             self._restore_go_to_zone()
@@ -3572,10 +3596,10 @@ class DreameMowerDevice:
         object_name = recovery_map_info.object_name
         if object_name and object_name != "":
             file, map_url, object_name = self.recovery_map_file(map_id, recovery_map_index)
-            if map_url == None:
+            if map_url is None:
                 raise InvalidActionException("Failed get recovery map file url: %s", object_name)
 
-            if file == None:
+            if file is None:
                 raise InvalidActionException("Failed to download recovery map file: %s", map_url)
 
             response = self.restore_map_from_file(map_url, map_id)
@@ -5310,7 +5334,7 @@ class DreameMowerDeviceStatus:
                 v.order
                 for k, v in sorted(
                     self.current_segments.items(),
-                    key=lambda s: s[1].order if s[1].order != None else 0,
+                    key=lambda s: s[1].order if s[1].order is not None else 0,
                 )
                 if v.order
             ]

--- a/custom_components/dreame_mower/dreame/map.py
+++ b/custom_components/dreame_mower/dreame/map.py
@@ -305,7 +305,7 @@ class DreameMapMowerMapManager:
             parameters[MAP_PARAMETER_TIME] = start_time
 
         result = self._request_map(parameters)
-        if result and result[MAP_PARAMETER_CODE] == 0:
+        if result and isinstance(result, dict) and result[MAP_PARAMETER_CODE] == 0:
             out = result[MAP_PARAMETER_OUT]
             _LOGGER.debug("Response from device %s", out)
             has_map = False
@@ -381,7 +381,7 @@ class DreameMapMowerMapManager:
                 MAP_REQUEST_PARAMETER_FRAME_TYPE: MapFrameType.P.name,
             }
         )
-        return bool(result and result[MAP_PARAMETER_CODE] == 0)
+        return bool(result and isinstance(result, dict) and result[MAP_PARAMETER_CODE] == 0)
 
     def _request_next_p_map(self, map_id: int, frame_id: int) -> bool:
         key = f"{map_id}:{frame_id}"
@@ -398,7 +398,7 @@ class DreameMapMowerMapManager:
                 MAP_REQUEST_PARAMETER_FRAME_TYPE: MapFrameType.P.name,
             }
         )
-        if result and result[MAP_PARAMETER_CODE] == 0:
+        if result and isinstance(result, dict) and result[MAP_PARAMETER_CODE] == 0:
             del self._request_queue[key]
 
             object_name = None
@@ -430,7 +430,7 @@ class DreameMapMowerMapManager:
 
     def _request_t_map(self) -> None:
         result = self._request_map({MAP_REQUEST_PARAMETER_FRAME_TYPE: "T"})
-        if result and result[MAP_PARAMETER_CODE] == 0:
+        if result and isinstance(result, dict) and result[MAP_PARAMETER_CODE] == 0:
             self.request_map_list()
 
     def _request_w_map(self) -> None:
@@ -1348,7 +1348,7 @@ class DreameMapMowerMapManager:
             return self._request_i_map()
         else:
             result = self._request_map()
-            if result and result[MAP_PARAMETER_CODE] == 0 and not self._protocol.dreame_cloud:
+            if result and isinstance(result, dict) and result[MAP_PARAMETER_CODE] == 0 and not self._protocol.dreame_cloud:
                 self._request_map_from_cloud()
 
     def request_next_map(self) -> None:

--- a/custom_components/dreame_mower/lawn_mower.py
+++ b/custom_components/dreame_mower/lawn_mower.py
@@ -130,7 +130,7 @@ STATE_CODE_TO_STATE: Final = {
     DreameMowerState.SPOT_CLEANING: LawnMowerActivity.MOWING,
     DreameMowerState.SHORTCUT: LawnMowerActivity.MOWING,
     DreameMowerState.WAITING_FOR_TASK: LawnMowerActivity.DOCKED,
-    DreameMowerState.SHORTCUT: LawnMowerActivity.MOWING,
+    DreameMowerState.STATION_CLEANING: LawnMowerActivity.DOCKED,
     DreameMowerState.MONITORING: LawnMowerActivity.MOWING,
     DreameMowerState.MONITORING_PAUSED: LawnMowerActivity.DOCKED,
 }
@@ -597,8 +597,6 @@ class DreameMower(DreameMowerEntity, LawnMowerEntity):
         # if ACTION_AVAILABILITY[DreameMowerAction.START_MOWING.name](self.device):
         self._attr_supported_features = self._attr_supported_features | LawnMowerEntityFeature.START_MOWING
         # if ACTION_AVAILABILITY[DreameMowerAction.PAUSE.name](self.device):
-        self._attr_supported_features = self._attr_supported_features | LawnMowerEntityFeature.PAUSE
-        # if ACTION_AVAILABILITY[DreameMowerAction.STOP.name](self.device):
         self._attr_supported_features = self._attr_supported_features | LawnMowerEntityFeature.PAUSE
         # if ACTION_AVAILABILITY[DreameMowerAction.DOCK.name](self.device):
         self._attr_supported_features = self._attr_supported_features | LawnMowerEntityFeature.DOCK

--- a/custom_components/dreame_mower/manifest.json
+++ b/custom_components/dreame_mower/manifest.json
@@ -18,5 +18,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "v0.0.5-alpha"
+  "version": "0.0.8"
 }

--- a/custom_components/dreame_mower/number.py
+++ b/custom_components/dreame_mower/number.py
@@ -40,6 +40,8 @@ class DreameMowerNumberEntityDescription(DreameMowerEntityDescription, NumberEnt
     segment_list_fn: Callable[[object], bool] = None
 
 
+SEGMENT_NUMBERS: tuple[DreameMowerNumberEntityDescription, ...] = ()
+
 NUMBERS: tuple[DreameMowerNumberEntityDescription, ...] = (
     DreameMowerNumberEntityDescription(
         property_key=DreameMowerProperty.VOLUME,

--- a/custom_components/dreame_mower/sensor.py
+++ b/custom_components/dreame_mower/sensor.py
@@ -313,7 +313,7 @@ SENSORS: tuple[DreameMowerSensorEntityDescription, ...] = (
     DreameMowerSensorEntityDescription(
         key="firmware_version",
         icon="mdi:chip",
-        value_fn=lambda value, device: device.info.version,
+        value_fn=lambda value, device: device.info.firmware_version,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "Dreame Mower",
   "render_readme": false,
-  "homeassistant": "2023.6.0",
-  "zip_release": true,
-  "filename": "dreame_mower.zip"
+  "homeassistant": "2023.6.0"
 }


### PR DESCRIPTION
## Summary

This PR fixes multiple bugs found through code analysis, GitHub issue review, and fork analysis (especially the janves fork).

### Bug Fixes

**`lawn_mower.py`**
- `DreameMowerState.SHORTCUT` was duplicated in `STATE_CODE_TO_STATE`; `DreameMowerState.STATION_CLEANING` was missing entirely (mapped as `DOCKED`)
- `LawnMowerEntityFeature.PAUSE` was set twice in `_set_attrs()`

**`number.py`**
- `SEGMENT_NUMBERS` was referenced in `async_update_segment_numbers()` but never defined → `NameError` at runtime

**`sensor.py`**
- Firmware Version sensor used `device.info.version` (returns only an integer like `550`) instead of `device.info.firmware_version` (returns full string like `4.3.6_0550`)

**`config_flow.py`**
- `DreameMowerOptionsFlowHandler.__init__` assigned `self.config_entry = config_entry` — deprecated in HA 2024.12+, causing a 500 error when opening integration settings
- `model_map[device["model"]]` raised `KeyError` for unknown models (e.g. `dreame.mower.g2568c`); fixed with `.get()` fallback

**`dreame/device.py`**
- `== None` / `!= None` comparisons replaced with `is None` / `is not None`
- Unknown property IDs from device caused `ValueError: X is not a valid DreameMowerProperty`, crashing the entire integration on startup. Added siid/piid reverse lookup (from janves fork) to gracefully map or skip unknown IDs
- `dock()` didn't properly end the mowing session (Issue #35); added status update when session is active

**`dreame/map.py`**
- `result[MAP_PARAMETER_CODE]` raised `TypeError` when the API returned a list instead of a dict; added `isinstance(result, dict)` guard at all 5 call sites

**`camera.py`**
- `AttributeError: 'DreameMowerCameraEntity' object has no attribute '_webrtc_provider'` because the Camera base class was not properly initialized for HA 2025+; fixed by setting `self._webrtc_provider = None` directly after `super().__init__()`

**`hacs.json`**
- `"zip_release": true` and `"filename": "dreame_mower.zip"` caused HACS installs to fail since no ZIP asset was attached to releases; removed both fields for standard source-based installs

## Test plan

- [ ] Integration loads without errors in HA 2024.x and 2025.x
- [ ] Firmware version sensor shows full string (e.g. `4.3.6_0550`) instead of bare integer
- [ ] Integration settings page opens without 500 error
- [ ] Unknown device models display their model ID instead of raising KeyError
- [ ] HACS install succeeds via source download (no ZIP release needed)
- [ ] `dock()` command properly ends the mowing session
- [ ] Camera entity initializes correctly on HA 2025+