### PR TITLE
Fix Dreame-cloud get_properties parsing: resolve properties by (siid, piid) instead of trusting 'did' (fixes #59)

### DIFF
--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -198,6 +198,13 @@ class DreameMowerDevice:
         self._dirty_data: dict[DreameMowerProperty, DirtyData] = {}
         self._dirty_auto_switch_data: dict[DreameMowerAutoSwitchProperty, DirtyData] = {}
         self._dirty_ai_data: dict[DreameMowerStrAIProperty | DreameMowerAIProperty, Any] = None
+        # Reverse lookup for resolving a property from the (siid, piid) of a response,
+        # first match wins in enum order like the lookup loop in _message_callback
+        self._property_by_siid_piid: dict[tuple[int, int], DreameMowerProperty] = {}
+        for prop in DreameMowerProperty:
+            mapping = self.property_mapping.get(prop)
+            if mapping and "aiid" not in mapping:
+                self._property_by_siid_piid.setdefault((mapping["siid"], mapping["piid"]), prop)
         self._discard_timeout = 5
         self._restore_timeout = 15
 
@@ -357,7 +364,20 @@ class DreameMowerDevice:
         for prop in properties:
             if not isinstance(prop, dict):
                 continue
-            did = int(prop["did"])
+            try:
+                did = int(prop["did"])
+                DreameMowerProperty(did)
+            except (KeyError, ValueError):
+                # Cloud responses can carry the device id in "did", fall back to (siid, piid)
+                mapped_prop = self._property_by_siid_piid.get((prop.get("siid"), prop.get("piid")))
+                if mapped_prop is None:
+                    _LOGGER.debug(
+                        "Skipping response with unmapped property: siid=%s piid=%s",
+                        prop.get("siid"),
+                        prop.get("piid"),
+                    )
+                    continue
+                did = mapped_prop.value
             if prop["code"] == 0 and "value" in prop:
                 value = prop["value"]
                 if did in self._dirty_data:
@@ -474,6 +494,14 @@ class DreameMowerDevice:
                     property_list.append({"did": str(prop.value), **mapping})
 
         results = self._protocol.get_properties(property_list)
+        if results:
+            # The Dreame cloud replies with the device id in "did" instead of echoing
+            # the requested property id, resolve by (siid, piid) like _message_callback does
+            for result in results:
+                if isinstance(result, dict):
+                    prop = self._property_by_siid_piid.get((result.get("siid"), result.get("piid")))
+                    if prop is not None:
+                        result["did"] = str(prop.value)
         return self._handle_properties(results)
 
     def _update_status(self, task_status: DreameMowerTaskStatus, status: DreameMowerStatus) -> None:

--- a/custom_components/dreame_mower/manifest.json
+++ b/custom_components/dreame_mower/manifest.json
@@ -18,5 +18,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "v0.0.5-alpha"
+  "version": "v0.0.6-alpha"
 }


### PR DESCRIPTION
## Problem

Setup fails for MOVA cloud models (MOVA LiDAX Ultra 1000 / 1200, MOVAhome app, EU region) with:

```
<negative number> is not a valid DreameMowerProperty
```

The negative number differs per device. Fixes #59.

## Root cause

This is a response-parsing bug, not a missing property in the enum.

`_request_properties` sends each requested key with `"did": str(prop.value)`, but the Dreame cloud's `get_properties` reply fills the `did` field of every returned property object with the **device id** (a large signed integer) instead of echoing the requested property id. `_handle_properties` then does `DreameMowerProperty(int(prop["did"]))` on the raw response and raises, aborting setup before any entities are created.

The push path (`_message_callback` handling `properties_changed`) does not have this problem because it already resolves each incoming param by `(siid, piid)` against `property_mapping` and rewrites `param["did"]` before calling `_handle_properties`. The codebase even accounts for this cloud behaviour on the write side already — `set_property` in `protocol.py` sends the device id as `did` when `dreame_cloud` is active.

## Fix

* Build a `(siid, piid) -> DreameMowerProperty` reverse lookup once in `DreameMowerDevice.__init__` (first match wins in enum order, mirroring the lookup loop in `_message_callback`).
* `_request_properties`: resolve each polled response object by `(siid, piid)` and rewrite its `did` to the property id — the same normalisation the push path performs.
* `_handle_properties`: if `did` still isn't a valid `DreameMowerProperty`, fall back to `(siid, piid)` resolution; if the pair is unmapped, skip the entry with a debug log instead of raising, so unknown model-specific properties are never setup-fatal.

## Testing

Verified on real hardware: MOVA LiDAX Ultra (A2 platform), MOVAhome account, EU/Germany region, Dreame cloud (no local connection).

* Before: config entry stuck in `setup_retry`, every attempt aborting with `... is not a valid DreameMowerProperty`, no entities.
* After: entry loads, 13 entities created with live data (lawn_mower state `docked`, battery level, charging status, device state, DnD switch, firmware version). The push path is unchanged.

Unrelated pre-existing issue observed on HA 2026.5: the map camera entity fails to add with `'DreameMowerCameraEntity' object has no attribute '_webrtc_provider'` — happy to file separately.

This should cover all MOVA cloud models, since the device id substitution happens server-side for any account on that cloud, including the 1000 from #59.

Note: the commit also bumps the manifest version to v0.0.6-alpha (used for HACS-based testing from my fork) — happy to drop that line if you prefer to version it yourself.