### PR TITLE
fix: handle unknown model IDs in Dreame account setup flow

### DIFF
--- a/custom_components/dreame_mower/config_flow.py
+++ b/custom_components/dreame_mower/config_flow.py
@@ -55,6 +55,7 @@ model_map = {
     "dreame.mower.p2255": "A1",
     "dreame.mower.g2422": "A1 Pro",
     "dreame.mower.g2408": "A2",
+    "dreame.mower.g2568d": "A2",
     "dreame.mower.g3255": "unknown",
 }
 
@@ -459,7 +460,7 @@ class DreameMowerFlowHandler(ConfigFlow, domain=DOMAIN):
                                 and len(device["customName"]) > 0
                                 else device["deviceInfo"]["displayName"]
                             )
-                            model = model_map[device["model"]]
+                            model = model_map.get(device["model"], device["model"])
                             modelId = device["model"]
                             list_name = f"{name} - {model} ({modelId})"
                             self.devices[list_name] = device


### PR DESCRIPTION
## Problem

Setting up the integration via a Dreame account raises a `KeyError` for any device whose model identifier is not in `model_map`. For example, the Dreame A2 EU variant ships with model ID `dreame.mower.g2568d`, which is absent from the map, causing:

```
KeyError: 'dreame.mower.g2568d'
```

The error occurs in `async_step_dreame` during device list enumeration.

## Fix

Two changes in `config_flow.py`:

1. **Add `dreame.mower.g2568d` to `model_map`** — EU variant of the A2 (confirmed with a live device).
2. **Use `.get()` with fallback** — `model_map[device["model"]]` → `model_map.get(device["model"], device["model"])`. Unknown model IDs now fall back to the raw model string instead of crashing, so future unrecognized variants degrade gracefully rather than blocking setup.

## Test

Verified on a live `dreame.mower.g2568d` device: setup flow completes successfully after this fix.