### PR TITLE
Add A1 Pro 2000 mapping and handle unknown model IDs

### DIFF
--- a/custom_components/dreame_mower/config_flow.py
+++ b/custom_components/dreame_mower/config_flow.py
@@ -54,6 +54,7 @@ DREAME_MODELS = [
 model_map = {
     "dreame.mower.p2255": "A1",
     "dreame.mower.g2422": "A1 Pro",
+    "dreame.mower.g2540d": "A1 Pro 2000",
     "dreame.mower.g2408": "A2",
     "dreame.mower.g3255": "unknown",
 }

--- a/custom_components/dreame_mower/config_flow.py
+++ b/custom_components/dreame_mower/config_flow.py
@@ -460,7 +460,9 @@ class DreameMowerFlowHandler(ConfigFlow, domain=DOMAIN):
                                 and len(device["customName"]) > 0
                                 else device["deviceInfo"]["displayName"]
                             )
-                            model = model_map[device["model"]]
+                            model = model_map.get(
+                                device["model"], device["model"]
+                            )
                             modelId = device["model"]
                             list_name = f"{name} - {model} ({modelId})"
                             self.devices[list_name] = device


### PR DESCRIPTION
## Summary

* Add `dreame.mower.g2540d` as `A1 Pro 2000` to `model_map`.
* Fall back to the raw model identifier when a mower is not yet listed in `model_map`.

## Problem

After a successful Dreame account login, the config flow crashes while enumerating devices:

```text
KeyError: 'dreame.mower.g2540d'
```

The integration accepts all devices whose model starts with `dreame.mower.`, but then accesses the finite model mapping directly:

```python
model = model_map[device["model"]]
```

Therefore, any new or previously unknown mower model blocks the entire setup flow.

## Fix

The A1 Pro 2000 model identifier is added to the mapping. The direct dictionary access is also replaced with a safe fallback so future unknown models use their raw model identifier instead of raising a `KeyError`.

## Validation

* Parsed the modified file successfully with Python's `ast` module.
* Verified that `dreame.mower.g2540d` resolves to `A1 Pro 2000`.
* Verified that an unknown model identifier falls back to its raw value.
* Confirmed that only `custom_components/dreame_mower/config_flow.py` is changed.

## Related work

The generic fallback overlaps with #73. This PR additionally includes the confirmed `dreame.mower.g2540d` mapping for the A1 Pro 2000.
