### PR TITLE
Remove obsolete recorder platform

### DIFF
--- a/custom_components/dreame_mower/camera.py
+++ b/custom_components/dreame_mower/camera.py
@@ -27,7 +27,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import entity_platform, entity_registry
-from .recorder import CAMERA_UNRECORDED_ATTRIBUTES
+from .unrecorded_attributes import CAMERA_UNRECORDED_ATTRIBUTES
 
 from .const import (
     DOMAIN,

--- a/custom_components/dreame_mower/lawn_mower.py
+++ b/custom_components/dreame_mower/lawn_mower.py
@@ -17,7 +17,7 @@ from homeassistant.components.lawn_mower import (
     LawnMowerEntity,
     LawnMowerEntityFeature,
 )
-from .recorder import MOWER_UNRECORDED_ATTRIBUTES
+from .unrecorded_attributes import MOWER_UNRECORDED_ATTRIBUTES
 
 from .dreame.const import STATE_UNKNOWN
 from .dreame import (

--- a/custom_components/dreame_mower/unrecorded_attributes.py
+++ b/custom_components/dreame_mower/unrecorded_attributes.py
@@ -1,8 +1,6 @@
-"""Integration platform for recorder."""
+"""State attributes excluded from recorder history."""
 
 from __future__ import annotations
-
-from homeassistant.core import HomeAssistant, callback
 
 from .dreame import DreameMowerProperty, DreameMowerAutoSwitchProperty
 from .dreame.const import (
@@ -118,9 +116,3 @@ MOWER_UNRECORDED_ATTRIBUTES = {
     DreameMowerAutoSwitchProperty.CLEANING_ROUTE.name.lower(),
     DreameMowerAutoSwitchProperty.CLEANGENIUS.name.lower(),
 }
-
-
-@callback
-def exclude_attributes(hass: HomeAssistant) -> set[str]:
-    """Exclude mower, camera and sensor attributes from being recorded in the database."""
-    return frozenset(CAMERA_UNRECORDED_ATTRIBUTES) | frozenset(MOWER_UNRECORDED_ATTRIBUTES)


### PR DESCRIPTION
## Summary

- rename `recorder.py` to `unrecorded_attributes.py`
- keep the existing camera and mower recorder exclusion sets unchanged
- update the camera and lawn mower imports to use the renamed module
- remove the obsolete recorder integration-platform callback

## Root cause

Home Assistant discovers any integration module named `recorder.py` as a recorder integration platform. It therefore imports `custom_components.dreame_mower.recorder` from the event loop during startup, which triggers a `homeassistant.util.loop` warning for the blocking `import_module` call.

Recorder platforms were replaced in Home Assistant 2023.10 by the `_unrecorded_attributes` entity class attribute. The integration already uses `_unrecorded_attributes` on both affected entity classes, so the platform callback is redundant; only the constants need to remain importable.

## User impact

Home Assistant no longer discovers or imports an obsolete recorder platform during startup. Existing recorder exclusions for mower and camera entities remain unchanged.

## Validation

- compiled the complete `custom_components/dreame_mower` package with `compileall`
- ran `git diff --check`
- verified there are no remaining `.recorder` imports or `exclude_attributes()` platform callbacks
- reproduced the original warning on Home Assistant 2026.8.1 and confirmed it no longer appears after removing the obsolete recorder platform

Reference: https://developers.home-assistant.io/blog/2023/09/20/excluding-state-attributes-from-recording/
